### PR TITLE
Update docs for multi-community architecture, add CI sync

### DIFF
--- a/.github/workflows/sync-osa-submodule.yml
+++ b/.github/workflows/sync-osa-submodule.yml
@@ -1,0 +1,40 @@
+name: Sync OSA Submodule
+
+on:
+  repository_dispatch:
+    types: [osa-updated]
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly Monday 6am UTC as fallback
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Update OSA submodule
+        run: |
+          git submodule update --remote osa
+          echo "Updated OSA submodule to $(git -C osa rev-parse --short HEAD)"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "sync: update OSA submodule to latest"
+          title: "sync: update OSA submodule to latest"
+          body: |
+            Automated update of the OSA submodule to track latest changes.
+
+            Triggered by: ${{ github.event_name }}
+          branch: sync/osa-submodule
+          labels: sync
+          delete-branch: true

--- a/docs/osa/cli-reference.md
+++ b/docs/osa/cli-reference.md
@@ -201,24 +201,40 @@ Options:
 
 ### `osa sync`
 
-Sync knowledge sources (GitHub issues/PRs, academic papers). Requires server dependencies.
-See [Knowledge Sync](knowledge-sync.md) for details.
+Sync knowledge sources for community assistants. Requires server dependencies. All subcommands accept `--community/-c` to specify the target community.
+
+See [Knowledge Sync](knowledge-sync.md) for full documentation.
 
 ```bash
-# Initialize database
-osa sync init
+# Initialize database for a community
+osa sync init --community hed
 
 # Sync GitHub issues/PRs
-osa sync github
+osa sync github --community bids
 
-# Sync academic papers
-osa sync papers
+# Sync academic papers (with citation tracking)
+osa sync papers --community bids
 
-# Sync everything
+# Sync code docstrings (MATLAB/Python)
+osa sync docstrings --community eeglab --language matlab
+
+# Sync mailing list archives
+osa sync mailman --community eeglab
+
+# Generate FAQ from mailing list threads
+osa sync faq --community eeglab --estimate
+
+# Sync BIDS Extension Proposals
+osa sync beps --community bids
+
+# Sync everything for all communities
 osa sync all
 
 # Check status
 osa sync status
+
+# Search knowledge database
+osa sync search "validation error" --community hed
 ```
 
 ## Configuration
@@ -273,10 +289,14 @@ These are only relevant when running the server (`osa serve`):
 | `LANGFUSE_PUBLIC_KEY` | LangFuse public key | Optional |
 | `LANGFUSE_SECRET_KEY` | LangFuse secret key | Optional |
 | `SYNC_ENABLED` | Enable automated knowledge sync | `true` |
-| `SYNC_GITHUB_CRON` | GitHub sync schedule (cron) | `0 2 * * *` |
-| `SYNC_PAPERS_CRON` | Papers sync schedule (cron) | `0 3 * * 0` |
-| `GITHUB_TOKEN` | GitHub token for sync | Optional |
+| `GITHUB_TOKEN` | GitHub token for sync (higher rate limits) | Optional |
+| `SEMANTIC_SCHOLAR_API_KEY` | Semantic Scholar API key | Optional |
+| `PUBMED_API_KEY` | PubMed/NCBI API key | Optional |
+| `OPENALEX_EMAIL` | Email for OpenALEX polite pool | Optional |
 | `DATA_DIR` | Data directory for knowledge DB | Platform-specific |
+
+!!! note "Sync Schedules"
+    Sync schedules are configured per-community in each community's `config.yaml` under the `sync` key, not via environment variables. See [Knowledge Sync](knowledge-sync.md) for details.
 
 ## Examples
 

--- a/docs/osa/knowledge-sync.md
+++ b/docs/osa/knowledge-sync.md
@@ -1,6 +1,6 @@
 # Knowledge Sync
 
-OSA includes a knowledge discovery system that syncs community-specific content from multiple sources. Each community gets its own SQLite FTS5 database at `data/knowledge/{community_id}.db`, populated by sync commands.
+OSA includes a knowledge discovery system that syncs community-specific content from multiple sources. Each community gets its own SQLite Full-Text Search 5 (FTS5) database at `data/knowledge/{community_id}.db`, populated by sync commands.
 
 ## Overview
 
@@ -8,11 +8,11 @@ The knowledge system supports six sync types:
 
 | Sync Type | Source | Description |
 |-----------|--------|-------------|
-| **GitHub** | GitHub REST API | Issues and PRs from community repositories |
+| **GitHub** | GitHub REST API | Issues and Pull Requests (PRs) from community repositories |
 | **Papers** | OpenALEX, Semantic Scholar, PubMed | Academic papers and citation tracking |
 | **Docstrings** | GitHub repos | MATLAB/Python function documentation |
 | **Mailman** | Mailman archives | Mailing list messages |
-| **FAQ** | LLM summarization | FAQ entries generated from mailing list threads |
+| **FAQ** | Large Language Model (LLM) summarization | Frequently Asked Questions (FAQ) entries generated from mailing list threads |
 | **BEPs** | bids-website + GitHub PRs | BIDS Extension Proposals (BIDS community only) |
 
 !!! note "Discovery, Not Answers"

--- a/docs/osa/registry/extensions.md
+++ b/docs/osa/registry/extensions.md
@@ -9,6 +9,8 @@ Extensions add specialized tools to community assistants beyond what YAML can au
 | Fetch documentation pages | Built-in (auto-generated from `documentation` config) |
 | Search GitHub issues/PRs | Built-in (auto-generated from `github` config) |
 | Search academic papers | Built-in (auto-generated from `citations` config) |
+| Search code docstrings | Built-in (auto-generated from `docstrings` config) |
+| Search mailing list FAQ | Built-in (auto-generated from `mailman` + `faq_generation` config) |
 | Call an external validation API | **Python plugin** |
 | Run a CLI tool | **Python plugin** |
 | Connect to an MCP server | **MCP server extension** |
@@ -109,9 +111,9 @@ Your module must define `__all__` listing the tools to export:
 __all__ = ["validate_config", "search_examples"]
 ```
 
-### Example: HED Tools
+### Examples from Implemented Communities
 
-The HED community has three specialized tools:
+**HED** - External API integration:
 
 | Tool | Purpose | External Dependency |
 |------|---------|---------------------|
@@ -119,7 +121,20 @@ The HED community has three specialized tools:
 | `suggest_hed_tags` | Natural language to HED tags | hed-lsp CLI tool |
 | `get_hed_schema_versions` | List available schema versions | hedtools.org REST API |
 
-These tools call external APIs that provide domain-specific functionality (validation, tag suggestion) which cannot be replicated in YAML configuration alone.
+**BIDS** - Specialized knowledge lookup:
+
+| Tool | Purpose | Data Source |
+|------|---------|-------------|
+| `lookup_bep` | Look up BIDS Extension Proposals | Synced BEP database |
+
+**EEGLAB** - Community-scoped wrappers:
+
+| Tool | Purpose | Data Source |
+|------|---------|-------------|
+| `search_eeglab_docstrings` | Search MATLAB/Python function docs | Synced docstrings database |
+| `search_eeglab_faqs` | Search mailing list FAQ entries | LLM-generated FAQ database |
+
+These tools provide domain-specific functionality that cannot be replicated in YAML configuration alone.
 
 ### Best Practices
 
@@ -182,13 +197,14 @@ Exactly one of `command` or `url` must be provided for each server.
 When a `CommunityAssistant` is created, tools are loaded in this order:
 
 1. **Knowledge tools** from YAML config:
-    - `list_{community}_recent` - Recent GitHub activity
-    - `search_{community}_discussions` - GitHub search
-    - `search_{community}_papers` - Academic paper search
+    - `search_{community}_discussions` - GitHub issues/PR search (if `github.repos` configured)
+    - `list_{community}_recent` - Recent GitHub activity (if `github.repos` configured)
+    - `search_{community}_papers` - Academic paper search (if `citations` configured)
+    - `search_{community}_code_docs` - Code docstring search (if `docstrings` configured)
+    - `search_{community}_faq` - Mailing list FAQ search (if `mailman` configured)
 2. **Documentation retrieval** - `retrieve_{community}_docs`
 3. **Page context** - `fetch_current_page` (if `enable_page_context: true`)
-4. **Additional tools** passed programmatically (if any)
-5. **Python plugin tools** from `extensions.python_plugins`
-6. **MCP server tools** from `extensions.mcp_servers` (when implemented)
+4. **Python plugin tools** from `extensions.python_plugins`
+5. **MCP server tools** from `extensions.mcp_servers` (when implemented)
 
 All tools are available to the LLM simultaneously. The system prompt should guide the LLM on when to use each tool.

--- a/docs/osa/registry/index.md
+++ b/docs/osa/registry/index.md
@@ -43,6 +43,10 @@ flowchart LR
 | System prompt | `system_prompt` | LLM instructions with placeholders |
 | Documentation | `documentation` list | Auto-generates `retrieve_docs` tool |
 | Knowledge sync | `github.repos`, `citations` | GitHub issues/PRs and paper sync |
+| Code docs | `docstrings` | MATLAB/Python docstring sync and search |
+| Mailing lists | `mailman`, `faq_generation` | Mailing list FAQ sync and search |
+| Sync schedules | `sync` | Per-type cron schedules |
+| Budget | `budget` | Daily/monthly spending limits |
 | Specialized tools | `extensions.python_plugins` | Loads custom Python tool functions |
 | Widget behavior | `enable_page_context` | Adds page context tool for embeds |
 
@@ -55,9 +59,12 @@ src/assistants/
     hed/
         config.yaml          # HED community configuration
         tools.py             # HED-specific tools (validation, tag suggestion)
-    bids/                    # Future
-        config.yaml
-        tools.py
+    bids/
+        config.yaml          # BIDS community configuration
+        tools.py             # BIDS-specific tools (BEP lookup)
+    eeglab/
+        config.yaml          # EEGLAB community configuration
+        tools.py             # EEGLAB-specific tools (docstring/FAQ search)
 ```
 
 ## Key Principles

--- a/docs/osa/registry/local-testing.md
+++ b/docs/osa/registry/local-testing.md
@@ -152,8 +152,8 @@ uv run osa sync init --community my-tool
 # Sync GitHub issues and PRs
 uv run osa sync github --community my-tool --full
 
-# Sync papers and citations
-uv run osa sync papers --community my-tool --citations
+# Sync papers (includes citation tracking by default)
+uv run osa sync papers --community my-tool
 
 # Or sync everything at once
 uv run osa sync all --community my-tool

--- a/docs/osa/registry/quick-start.md
+++ b/docs/osa/registry/quick-start.md
@@ -130,8 +130,8 @@ If you configured GitHub repos or citations, sync the knowledge database:
 # Sync GitHub issues/PRs
 uv run osa sync github --community my-tool
 
-# Sync papers and citations
-uv run osa sync papers --community my-tool --citations
+# Sync papers (includes citation tracking by default)
+uv run osa sync papers --community my-tool
 
 # Or sync everything
 uv run osa sync all --community my-tool

--- a/docs/osa/tools/bids.md
+++ b/docs/osa/tools/bids.md
@@ -7,7 +7,7 @@ The Brain Imaging Data Structure (BIDS) assistant provides tools for documentati
 | Tool | Type | Description |
 |------|------|-------------|
 | `retrieve_bids_docs` | Document retrieval | Fetch BIDS specification and website docs |
-| `search_bids_discussions` | Knowledge search | Search GitHub issues and PRs |
+| `search_bids_discussions` | Knowledge search | Search GitHub issues and Pull Requests (PRs) |
 | `list_bids_recent` | Knowledge search | List recent GitHub activity |
 | `search_bids_papers` | Knowledge search | Search academic papers |
 | `lookup_bep` | BIDS-specific | Look up BIDS Extension Proposals |
@@ -16,7 +16,7 @@ The Brain Imaging Data Structure (BIDS) assistant provides tools for documentati
 
 ### `retrieve_bids_docs`
 
-Fetches documentation from configured BIDS sources. The BIDS assistant has 49 configured documentation pages spanning the specification, website, and FAQ.
+Fetches documentation from configured BIDS sources. The BIDS assistant has 46 configured documentation pages spanning the specification, website, and FAQ.
 
 **Preloaded docs** (embedded in system prompt):
 

--- a/docs/osa/tools/bids.md
+++ b/docs/osa/tools/bids.md
@@ -1,0 +1,158 @@
+# BIDS Tools
+
+The Brain Imaging Data Structure (BIDS) assistant provides tools for documentation retrieval, knowledge search, and BIDS Extension Proposal (BEP) lookup.
+
+## Overview
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `retrieve_bids_docs` | Document retrieval | Fetch BIDS specification and website docs |
+| `search_bids_discussions` | Knowledge search | Search GitHub issues and PRs |
+| `list_bids_recent` | Knowledge search | List recent GitHub activity |
+| `search_bids_papers` | Knowledge search | Search academic papers |
+| `lookup_bep` | BIDS-specific | Look up BIDS Extension Proposals |
+
+## Document Retrieval
+
+### `retrieve_bids_docs`
+
+Fetches documentation from configured BIDS sources. The BIDS assistant has 49 configured documentation pages spanning the specification, website, and FAQ.
+
+**Preloaded docs** (embedded in system prompt):
+
+- BIDS common principles
+- Getting started with BIDS
+
+**On-demand docs** (fetched when needed): specification core, modality-specific files (MRI, EEG, MEG, iEEG, PET, NIRS, Motion, Microscopy, MRS, EMG, Behavioral, Genetics, Physiological), derivatives, getting started guides, FAQ, schema documentation, and more.
+
+Documents are organized by category: `core`, `specification`, `modality_agnostic`, `modality_specific`, `derivatives`, `getting_started`, `faq`, `tools`, `extensions`, `schema`.
+
+## Knowledge Search Tools
+
+These tools search the BIDS community's synced knowledge database. They require running `osa sync` commands to populate data (see [Knowledge Sync](../knowledge-sync.md)).
+
+### `search_bids_discussions`
+
+Search GitHub issues and PRs across BIDS repositories.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Search query (keywords, issue numbers) |
+| `include_issues` | `bool` | `True` | Include issues in results |
+| `include_prs` | `bool` | `True` | Include pull requests in results |
+| `limit` | `int` | `5` | Maximum results to return |
+
+**Tracked repositories:**
+
+- `bids-standard/bids-specification`
+- `bids-standard/bids-validator`
+- `bids-standard/bids-website`
+- `bids-standard/bids-examples`
+
+**Example interaction:**
+
+```
+User: "Are there any discussions about derivatives?"
+Agent: calls search_bids_discussions(query="derivatives")
+Agent: "There's a related discussion: [link to actual issue]"
+```
+
+### `list_bids_recent`
+
+List recent GitHub activity ordered by creation date.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `item_type` | `str` | `"all"` | Filter: `"all"`, `"issue"`, or `"pr"` |
+| `repo` | `str \| None` | `None` | Filter by repository (e.g., `"bids-standard/bids-specification"`) |
+| `status` | `str \| None` | `None` | Filter: `"open"` or `"closed"` |
+| `limit` | `int` | `10` | Maximum results to return |
+
+**Example interaction:**
+
+```
+User: "What are the latest PRs in the specification?"
+Agent: calls list_bids_recent(item_type="pr", repo="bids-standard/bids-specification")
+```
+
+### `search_bids_papers`
+
+Search academic papers related to BIDS.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Search query |
+| `limit` | `int` | `5` | Maximum results to return |
+
+**Tracked citation DOIs:**
+
+The BIDS assistant tracks papers citing 14 core DOIs, including:
+
+- Gorgolewski et al. (2016) - The brain imaging data structure
+- EEG-BIDS (Pernet et al., 2019)
+- MEG-BIDS (Niso et al., 2018)
+- iEEG-BIDS (Holdgraf et al., 2019)
+- PET-BIDS (Norgaard et al., 2021)
+- And 9 additional modality-specific extension papers
+
+Papers are sourced from OpenALEX, Semantic Scholar, and PubMed.
+
+## BIDS-Specific Tools
+
+### `lookup_bep`
+
+Look up BIDS Extension Proposals (BEPs) by number or keyword. BEPs are the mechanism for adding new data types to BIDS. This tool searches over synced BEP specification content from open pull requests against the BIDS specification.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | BEP number (e.g., `"032"`, `"BEP032"`) or keyword (e.g., `"neuropixels"`) |
+| `limit` | `int` | `3` | Maximum results to return |
+
+**Returns:** Formatted BEP information including:
+
+- BEP number and title
+- Current status (proposed, draft, etc.)
+- Lead authors
+- Links to the PR, HTML preview, and/or Google Doc
+- Content snippet from the proposal
+
+**Example:**
+
+```
+User: "Is there a BEP for eye tracking data?"
+Agent: calls lookup_bep(query="eye tracking")
+Response:
+  Found 1 BEP(s):
+
+  **BEP020: Eye Tracking including Gaze Position and Pupil Size**
+  Status: proposed
+  PR: https://github.com/bids-standard/bids-specification/pull/...
+  Preview: https://bids-specification--...readthedocs.build/...
+```
+
+!!! note "Sync Required"
+    The `lookup_bep` tool requires running `osa sync beps --community bids` to populate BEP data from open specification PRs.
+
+## Sync Configuration
+
+The BIDS assistant's knowledge sync is configured in its `config.yaml`:
+
+```yaml
+sync:
+  github:
+    cron: "0 2 * * *"       # daily at 2am UTC
+  papers:
+    cron: "0 3 * * 0"       # weekly Sunday at 3am UTC
+  beps:
+    cron: "0 4 * * 1"       # weekly Monday at 4am UTC
+```
+
+See [Knowledge Sync](../knowledge-sync.md) for CLI commands and setup instructions.

--- a/docs/osa/tools/eeglab.md
+++ b/docs/osa/tools/eeglab.md
@@ -1,6 +1,6 @@
 # EEGLAB Tools
 
-The EEGLAB assistant provides tools for documentation retrieval, knowledge search, code docstring search, and mailing list FAQ search.
+The EEGLAB assistant provides tools for documentation retrieval, knowledge search, code docstring search, and mailing list Frequently Asked Questions (FAQ) search.
 
 ## Overview
 
@@ -17,14 +17,14 @@ The EEGLAB assistant provides tools for documentation retrieval, knowledge searc
 
 ### `retrieve_eeglab_docs`
 
-Fetches documentation from 22 configured EEGLAB sources, covering installation, data import, preprocessing, ICA, visualization, group analysis, scripting, and plugin integration.
+Fetches documentation from 25 configured EEGLAB sources, covering setup, data import, preprocessing, Independent Component Analysis (ICA), visualization, group analysis, scripting, and plugin integration.
 
 **Preloaded docs** (embedded in system prompt):
 
 - EEGLAB quickstart (installation and basic functionality)
 - Dataset management
 
-**On-demand docs:** data import (3 docs), preprocessing (4 docs), ICA and artifacts (4 docs), epoching, visualization (4 docs), group analysis (2 docs), scripting (2 docs), and integration (2 docs: BIDS, LSL).
+**On-demand docs:** setup (1 doc), data import (3 docs), preprocessing (4 docs), ICA and artifacts (4 docs), epoching, visualization (4 docs), group analysis (2 docs), scripting (2 docs), and integration (2 docs: BIDS, Lab Streaming Layer).
 
 ## Knowledge Search Tools
 
@@ -124,7 +124,7 @@ Response:
 
 ### `search_eeglab_faqs`
 
-Search FAQ entries generated from the EEGLAB mailing list archive (since 2004). The FAQ database is created using a two-agent LLM pipeline that evaluates thread quality and summarizes high-quality discussions.
+Search FAQ entries generated from the EEGLAB mailing list archive (since 2004). The FAQ database is created using a two-agent Large Language Model (LLM) pipeline that evaluates thread quality and summarizes high-quality discussions.
 
 **Parameters:**
 

--- a/docs/osa/tools/eeglab.md
+++ b/docs/osa/tools/eeglab.md
@@ -1,0 +1,194 @@
+# EEGLAB Tools
+
+The EEGLAB assistant provides tools for documentation retrieval, knowledge search, code docstring search, and mailing list FAQ search.
+
+## Overview
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `retrieve_eeglab_docs` | Document retrieval | Fetch EEGLAB tutorials and guides |
+| `search_eeglab_discussions` | Knowledge search | Search GitHub issues and PRs |
+| `list_eeglab_recent` | Knowledge search | List recent GitHub activity |
+| `search_eeglab_papers` | Knowledge search | Search academic papers |
+| `search_eeglab_docstrings` | EEGLAB-specific | Search MATLAB/Python function documentation |
+| `search_eeglab_faqs` | EEGLAB-specific | Search mailing list FAQ entries |
+
+## Document Retrieval
+
+### `retrieve_eeglab_docs`
+
+Fetches documentation from 22 configured EEGLAB sources, covering installation, data import, preprocessing, ICA, visualization, group analysis, scripting, and plugin integration.
+
+**Preloaded docs** (embedded in system prompt):
+
+- EEGLAB quickstart (installation and basic functionality)
+- Dataset management
+
+**On-demand docs:** data import (3 docs), preprocessing (4 docs), ICA and artifacts (4 docs), epoching, visualization (4 docs), group analysis (2 docs), scripting (2 docs), and integration (2 docs: BIDS, LSL).
+
+## Knowledge Search Tools
+
+These tools search the EEGLAB community's synced knowledge database.
+
+### `search_eeglab_discussions`
+
+Search GitHub issues and PRs across EEGLAB repositories.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Search query |
+| `include_issues` | `bool` | `True` | Include issues in results |
+| `include_prs` | `bool` | `True` | Include pull requests |
+| `limit` | `int` | `5` | Maximum results |
+
+**Tracked repositories:**
+
+- `sccn/eeglab`
+- `sccn/ICLabel`
+- `sccn/clean_rawdata`
+- `sccn/EEG-BIDS`
+- `sccn/labstreaminglayer`
+- `sccn/liblsl`
+
+### `list_eeglab_recent`
+
+List recent GitHub activity ordered by creation date.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `item_type` | `str` | `"all"` | Filter: `"all"`, `"issue"`, or `"pr"` |
+| `repo` | `str \| None` | `None` | Filter by repository (e.g., `"sccn/eeglab"`) |
+| `status` | `str \| None` | `None` | Filter: `"open"` or `"closed"` |
+| `limit` | `int` | `10` | Maximum results |
+
+### `search_eeglab_papers`
+
+Search academic papers related to EEGLAB.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Search query |
+| `limit` | `int` | `5` | Maximum results |
+
+**Tracked citation DOIs:**
+
+- Delorme & Makeig (2004) - EEGLAB: an open source toolbox
+- Pion-Tonachini et al. (2019) - ICLabel: automated EEG IC classification
+- Bigdely-Shamlo et al. (2015) - PREP: standardized preprocessing
+
+## EEGLAB-Specific Tools
+
+### `search_eeglab_docstrings`
+
+Search function documentation from the EEGLAB codebase. This tool searches over MATLAB and Python docstrings extracted from EEGLAB and its plugins.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Function name or description (e.g., `"pop_loadset"`, `"ICA decomposition"`) |
+| `limit` | `int` | `5` | Maximum results |
+| `language` | `str \| None` | `None` | Filter by language: `"matlab"` or `"python"` |
+
+**Indexed repositories:**
+
+| Repository | Branch | Languages |
+|-----------|--------|-----------|
+| `sccn/eeglab` | `develop` | MATLAB, Python |
+| `sccn/ICLabel` | `master` | MATLAB |
+| `sccn/clean_rawdata` | `master` | MATLAB |
+
+**Example:**
+
+```
+User: "How do I use pop_loadset?"
+Agent: calls search_eeglab_docstrings(query="pop_loadset")
+Response:
+  Found 1 function(s):
+
+  **1. pop_loadset (function) - functions/popfunc/pop_loadset.m**
+  Language: matlab
+  [View source](https://github.com/sccn/eeglab/blob/.../pop_loadset.m#L1)
+
+  Load an EEGLAB dataset file...
+```
+
+!!! note "Sync Required"
+    Populate with `osa sync docstrings --community eeglab`.
+
+### `search_eeglab_faqs`
+
+Search FAQ entries generated from the EEGLAB mailing list archive (since 2004). The FAQ database is created using a two-agent LLM pipeline that evaluates thread quality and summarizes high-quality discussions.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Search query (topic or question) |
+| `category` | `str \| None` | `None` | Filter by category (e.g., `"troubleshooting"`, `"how-to"`, `"bug-report"`) |
+| `limit` | `int` | `5` | Maximum results |
+
+**Returns:** FAQ entries with:
+
+- Question and answer summary
+- Category classification
+- Quality score (0.0-1.0)
+- Tags
+- Link to original mailing list thread
+
+**Example:**
+
+```
+User: "How do I remove artifacts from EEG data?"
+Agent: calls search_eeglab_faqs(query="artifact removal")
+Response:
+  Found 3 FAQ entries:
+
+  **1. How do I remove artifacts from my EEG data?**
+  Category: how-to | Quality: 0.9/1.0
+  Tags: artifacts, preprocessing, ICA
+
+  There are several approaches to artifact removal in EEGLAB...
+
+  [View thread](https://sccn.ucsd.edu/pipermail/eeglablist/...)
+```
+
+!!! note "Sync Required"
+    Populate with `osa sync mailman --community eeglab` followed by `osa sync faq --community eeglab`.
+
+### FAQ Generation Pipeline
+
+The FAQ entries are generated through a two-stage LLM pipeline:
+
+1. **Evaluation agent** - Scores each mailing list thread for quality using a fast, cost-efficient model. Threads must have at least 2 messages from 2 participants.
+2. **Summary agent** - Creates structured FAQ entries (question, answer, category, tags) from threads scoring above the quality threshold (default: 0.7).
+
+This approach filters out low-quality threads early, keeping costs manageable even for archives spanning 20+ years.
+
+Configuration is in the community's `config.yaml` under `faq_generation`. See [Schema Reference](../registry/schema-reference.md) for details.
+
+## Sync Configuration
+
+The EEGLAB assistant's knowledge sync schedule:
+
+```yaml
+sync:
+  github:
+    cron: "0 2 * * *"       # daily at 2am UTC
+  papers:
+    cron: "0 3 * * 0"       # weekly Sunday at 3am UTC
+  docstrings:
+    cron: "0 4 * * 1"       # weekly Monday at 4am UTC
+  mailman:
+    cron: "0 5 * * 1"       # weekly Monday at 5am UTC
+  faq:
+    cron: "0 6 1 * *"       # monthly 1st at 6am UTC
+```
+
+See [Knowledge Sync](../knowledge-sync.md) for CLI commands and setup instructions.

--- a/docs/osa/tools/index.md
+++ b/docs/osa/tools/index.md
@@ -44,11 +44,11 @@ Each community gets a `retrieve_{community}_docs` tool that fetches documentatio
 
 ### Knowledge Search
 
-Community-scoped tools for searching synced knowledge databases. All tools search the community's SQLite FTS5 database at `data/knowledge/{community_id}.db`.
+Community-scoped tools for searching synced knowledge databases. All tools search the community's SQLite Full-Text Search 5 (FTS5) database at `data/knowledge/{community_id}.db`.
 
 | Tool Name | Description | Requires |
 |-----------|-------------|----------|
-| `search_{community}_discussions` | Search GitHub issues and PRs | `github.repos` in config |
+| `search_{community}_discussions` | Search GitHub issues and Pull Requests (PRs) | `github.repos` in config |
 | `list_{community}_recent` | List recent GitHub activity by date | `github.repos` in config |
 | `search_{community}_papers` | Search academic papers (OpenALEX, Semantic Scholar, PubMed) | `citations` in config |
 | `search_{community}_code_docs` | Search code docstrings (MATLAB/Python) | `docstrings` in config |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,5 +169,7 @@ nav:
       - Tools:
           - osa/tools/index.md
           - HED Tools: osa/tools/hed.md
+          - BIDS Tools: osa/tools/bids.md
+          - EEGLAB Tools: osa/tools/eeglab.md
       - Development: osa/development.md
       - Version Management: osa/version-management.md


### PR DESCRIPTION
## Summary

- Add CI workflow to auto-sync OSA submodule (receives dispatch from OSA repo, opens/updates PR)
- Create BIDS tools documentation page (lookup_bep, knowledge tools, 49 doc sources)
- Create EEGLAB tools documentation page (docstring search, FAQ search, 22 doc sources)
- Rewrite tools overview for community-scoped tool naming
- Rewrite knowledge-sync.md for multi-community architecture (--community flags, 4 new sync types)
- Fix HED tools docs (return types, add missing knowledge tools)
- Update CLI reference with new sync subcommands
- Update schema reference with mailman, docstrings, faq_generation, sync, budget sections
- Fix registry pages (BIDS/EEGLAB as implemented, correct tool loading order)

## Remaining work

- [ ] The OSA repo needs `notify-docs.yml` workflow and a `DOCS_REPO_TOKEN` secret added separately
- [ ] BIDS and EEGLAB tool pages should be reviewed against latest source

## Test plan

- [x] `uv run mkdocs build` succeeds
- [ ] Verify navigation includes new BIDS and EEGLAB tool pages
- [ ] Spot-check new/updated pages on Cloudflare Pages preview