### PR TITLE
Replace architecture Mermaid diagrams with SVG

### DIFF
--- a/docs/osa/architecture-details.md
+++ b/docs/osa/architecture-details.md
@@ -1,0 +1,120 @@
+# Architecture Details
+
+This page shows the internal structure of the OSA platform, including all components, data flows, and external service connections.
+
+<figure markdown="span">
+  ![OSA Detailed Architecture](architecture-diagram.svg){ width="100%" }
+  <figcaption>Detailed infrastructure diagram showing all components and data flows</figcaption>
+</figure>
+
+---
+
+## Request Flow
+
+A typical request flows through the system as follows:
+
+1. **Client** (CLI, widget, or API consumer) sends an HTTPS request to `api.osc.earth`
+2. **Apache reverse proxy** strips the `/osa/` prefix and forwards to the Docker container
+3. **FastAPI** validates authentication (API key or BYOK headers) and CORS origin
+4. **Community router** (e.g., `/hed/ask`) handles the request using the community's configuration
+5. **LangGraph agent** runs the conversation loop:
+    - Sends messages to the LLM via **LiteLLM** (through OpenRouter)
+    - LLM may request **tool calls** (document retrieval, knowledge search, validation)
+    - Tools query **SQLite + FTS5** databases or external APIs (GitHub, hedtools.org)
+    - Loop continues until the agent produces a final response
+6. **Response** is streamed back to the client via SSE (Server-Sent Events)
+7. **LangFuse** records the trace for observability
+
+---
+
+## Community Routing
+
+Routes are created dynamically at startup from the YAML registry:
+
+```python
+# src/api/main.py - simplified
+for community in registry.list_available():
+    router = create_community_router(community.id)
+    app.include_router(router)  # Creates /{community_id}/ask, /chat, etc.
+```
+
+Each community gets four endpoints:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/{id}/` | GET | Community configuration (public) |
+| `/{id}/ask` | POST | Single question (no history) |
+| `/{id}/chat` | POST | Multi-turn conversation with session |
+| `/{id}/sessions` | GET | List active sessions |
+
+---
+
+## Model Selection
+
+Model selection follows a priority chain:
+
+```
+User requests custom model (requires BYOK)
+    |
+    v  (no custom model)
+Community default_model (from config.yaml)
+    |
+    v  (no community override)
+Platform default_model (from settings)
+```
+
+This allows communities to choose their preferred model while giving users with BYOK the freedom to use any model.
+
+---
+
+## Knowledge System
+
+Each community has its own SQLite database with FTS5 full-text search:
+
+```
+/app/data/knowledge/
+    hed.db       - HED issues, PRs, documentation
+    eeglab.db    - EEGLAB issues, PRs, documentation
+    mne.db       - MNE issues, PRs, documentation
+```
+
+Knowledge is synced from GitHub via the `osa sync` CLI command, which fetches issues and PRs and indexes them for full-text search with BM25 ranking.
+
+### Why SQLite + FTS5?
+
+For single-instance lab deployment, SQLite with FTS5 is the optimal choice:
+
+| Approach | Search Speed | Dependencies | Use Case |
+|----------|-------------|--------------|----------|
+| JSON files | O(n) linear | None | Tiny datasets (<1K) |
+| **SQLite + FTS5** | **O(log n) indexed** | **None (stdlib)** | **Single instance, 10K-1M records** |
+| PostgreSQL | O(log n) indexed | External server | Multi-instance |
+
+Advantages: no external server, BM25 ranking, 100-1000x faster than linear scan, Python stdlib, easy backup (copy the file).
+
+---
+
+## Security Layers
+
+| Layer | Protects Against | Location |
+|-------|-----------------|----------|
+| HTTPS / TLS | Man-in-the-middle | Let's Encrypt via Apache |
+| API Key auth | Unauthorized access | FastAPI middleware |
+| CORS validation | Cross-origin attacks | FastAPI middleware (per-community origins) |
+| BYOK isolation | Key exposure | Keys forwarded, never stored |
+
+---
+
+## CI/CD Pipeline
+
+```
+GitHub Actions (build/test)
+    -> GHCR Docker Image (:dev or :latest)
+    -> SSH deploy script
+    -> docker pull + restart on lab server
+```
+
+| Branch | Docker Tag | Deployment |
+|--------|-----------|------------|
+| `develop` | `:dev` | `api.osc.earth/osa-dev` (port 38529) |
+| `main` | `:latest` + GitHub Release | `api.osc.earth/osa` (port 38528) |

--- a/docs/osa/architecture-diagram.svg
+++ b/docs/osa/architecture-diagram.svg
@@ -1,0 +1,367 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 980" font-family="'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc"/>
+      <stop offset="100%" stop-color="#f1f5f9"/>
+    </linearGradient>
+    <linearGradient id="clientGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#eff6ff"/>
+      <stop offset="100%" stop-color="#dbeafe"/>
+    </linearGradient>
+    <linearGradient id="edgeGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fef3c7"/>
+      <stop offset="100%" stop-color="#fde68a"/>
+    </linearGradient>
+    <linearGradient id="serverGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ecfdf5"/>
+      <stop offset="100%" stop-color="#d1fae5"/>
+    </linearGradient>
+    <linearGradient id="dataGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5f3ff"/>
+      <stop offset="100%" stop-color="#ede9fe"/>
+    </linearGradient>
+    <linearGradient id="extGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff1f2"/>
+      <stop offset="100%" stop-color="#ffe4e6"/>
+    </linearGradient>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.08"/>
+    </filter>
+    <filter id="shadowLight" x="-2%" y="-2%" width="104%" height="104%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1" flood-opacity="0.06"/>
+    </filter>
+    <!-- Arrow markers -->
+    <marker id="arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrowRed" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#f87171"/>
+    </marker>
+    <marker id="arrowPurple" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#a78bfa"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1100" height="980" fill="url(#bgGrad)" rx="12"/>
+
+  <!-- Title -->
+  <text x="550" y="38" text-anchor="middle" font-size="20" font-weight="700" fill="#1e293b">OSA Infrastructure Architecture</text>
+  <text x="550" y="56" text-anchor="middle" font-size="11" fill="#64748b">Open Science Assistant -- Actual deployed system (March 2026)</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- CLIENT LAYER  y=72..172 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="30" y="72" width="1040" height="100" rx="10" fill="url(#clientGrad)" stroke="#93c5fd" stroke-width="1" filter="url(#shadow)"/>
+  <text x="50" y="92" font-size="11" font-weight="600" fill="#1e40af" letter-spacing="1">CLIENTS</text>
+
+  <rect x="60" y="102" width="180" height="56" rx="8" fill="white" stroke="#93c5fd" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="150" y="124" text-anchor="middle" font-size="13" font-weight="600" fill="#1e3a5f">CLI (Typer + Rich)</text>
+  <text x="150" y="142" text-anchor="middle" font-size="10" fill="#64748b">pip install open-science-assistant</text>
+
+  <rect x="280" y="102" width="200" height="56" rx="8" fill="white" stroke="#93c5fd" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="380" y="124" text-anchor="middle" font-size="13" font-weight="600" fill="#1e3a5f">Web Chat Widget</text>
+  <text x="380" y="142" text-anchor="middle" font-size="10" fill="#64748b">osa-chat-widget.js (embedded)</text>
+
+  <rect x="520" y="102" width="180" height="56" rx="8" fill="white" stroke="#93c5fd" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="610" y="124" text-anchor="middle" font-size="13" font-weight="600" fill="#1e3a5f">REST API Clients</text>
+  <text x="610" y="142" text-anchor="middle" font-size="10" fill="#64748b">curl, httpx, fetch, etc.</text>
+
+  <rect x="740" y="102" width="310" height="56" rx="8" fill="#f0f9ff" stroke="#bfdbfe" stroke-width="1" stroke-dasharray="4,2"/>
+  <text x="895" y="120" text-anchor="middle" font-size="10" font-weight="600" fill="#1e40af">Authentication</text>
+  <text x="895" y="134" text-anchor="middle" font-size="9.5" fill="#475569">X-API-Key (server key) or BYOK:</text>
+  <text x="895" y="148" text-anchor="middle" font-size="9.5" fill="#475569">X-OpenRouter-Key / X-OpenAI-API-Key / X-Anthropic-API-Key</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- EDGE / PROXY LAYER  y=192..282 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="30" y="192" width="1040" height="90" rx="10" fill="url(#edgeGrad)" stroke="#fbbf24" stroke-width="1" filter="url(#shadow)"/>
+  <text x="50" y="212" font-size="11" font-weight="600" fill="#92400e" letter-spacing="1">EDGE / HOSTING</text>
+
+  <rect x="60" y="222" width="240" height="48" rx="8" fill="white" stroke="#f59e0b" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="180" y="244" text-anchor="middle" font-size="13" font-weight="600" fill="#78350f">Cloudflare Pages</text>
+  <text x="180" y="258" text-anchor="middle" font-size="10" fill="#64748b">demo.osc.earth (widget hosting)</text>
+
+  <rect x="360" y="222" width="340" height="48" rx="8" fill="white" stroke="#f59e0b" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="530" y="244" text-anchor="middle" font-size="13" font-weight="600" fill="#78350f">Apache Reverse Proxy (api.osc.earth)</text>
+  <text x="530" y="258" text-anchor="middle" font-size="10" fill="#64748b">/osa/ -> :38528 (prod)    /osa-dev/ -> :38529 (dev)</text>
+
+  <rect x="740" y="222" width="120" height="48" rx="8" fill="#fef9c3" stroke="#eab308" stroke-width="1"/>
+  <text x="800" y="244" text-anchor="middle" font-size="11" font-weight="600" fill="#854d0e">HTTPS / TLS</text>
+  <text x="800" y="258" text-anchor="middle" font-size="10" fill="#64748b">Let's Encrypt</text>
+
+  <rect x="880" y="222" width="170" height="48" rx="8" fill="#fef9c3" stroke="#eab308" stroke-width="1"/>
+  <text x="965" y="244" text-anchor="middle" font-size="11" font-weight="600" fill="#854d0e">CORS Validation</text>
+  <text x="965" y="258" text-anchor="middle" font-size="10" fill="#64748b">Origin-based per community</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- SERVER LAYER  y=302..610 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="30" y="302" width="1040" height="308" rx="10" fill="url(#serverGrad)" stroke="#6ee7b7" stroke-width="1" filter="url(#shadow)"/>
+  <text x="50" y="322" font-size="11" font-weight="600" fill="#065f46" letter-spacing="1">APPLICATION SERVER (Docker Container)</text>
+  <text x="940" y="322" font-size="10" fill="#065f46">ghcr.io/openscience-collective/osa</text>
+
+  <!-- FastAPI box y=334..394 -->
+  <rect x="60" y="334" width="990" height="60" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="80" y="358" font-size="14" font-weight="700" fill="#065f46">FastAPI</text>
+  <text x="80" y="378" font-size="10" fill="#64748b">Single instance, uvicorn, SSE streaming, CORS middleware, API key auth</text>
+  <rect x="780" y="344" width="100" height="28" rx="6" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="830" y="363" text-anchor="middle" font-size="10" fill="#065f46">GET /health</text>
+  <rect x="890" y="344" width="140" height="28" rx="6" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="960" y="363" text-anchor="middle" font-size="10" fill="#065f46">GET /communities</text>
+
+  <!-- Community Routers y=406..516 -->
+  <rect x="60" y="406" width="460" height="110" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="80" y="426" font-size="12" font-weight="600" fill="#065f46">Community Routers (dynamic, from YAML registry)</text>
+
+  <rect x="80" y="438" width="125" height="64" rx="6" fill="#f0fdf4" stroke="#86efac" stroke-width="1"/>
+  <text x="142" y="458" text-anchor="middle" font-size="11" font-weight="600" fill="#166534">/hed/</text>
+  <text x="142" y="472" text-anchor="middle" font-size="9" fill="#64748b">ask, chat, sessions</text>
+  <text x="142" y="486" text-anchor="middle" font-size="8.5" fill="#94a3b8">config.yaml + prompt</text>
+  <text x="142" y="496" text-anchor="middle" font-size="8.5" fill="#94a3b8">+ tools + extensions</text>
+
+  <rect x="220" y="438" width="125" height="64" rx="6" fill="#f0fdf4" stroke="#86efac" stroke-width="1"/>
+  <text x="282" y="458" text-anchor="middle" font-size="11" font-weight="600" fill="#166534">/eeglab/</text>
+  <text x="282" y="472" text-anchor="middle" font-size="9" fill="#64748b">ask, chat, sessions</text>
+  <text x="282" y="486" text-anchor="middle" font-size="8.5" fill="#94a3b8">config.yaml + prompt</text>
+  <text x="282" y="496" text-anchor="middle" font-size="8.5" fill="#94a3b8">+ tools + extensions</text>
+
+  <rect x="360" y="438" width="125" height="64" rx="6" fill="#f0fdf4" stroke="#86efac" stroke-width="1"/>
+  <text x="422" y="458" text-anchor="middle" font-size="11" font-weight="600" fill="#166534">/mne/</text>
+  <text x="422" y="472" text-anchor="middle" font-size="9" fill="#64748b">ask, chat, sessions</text>
+  <text x="422" y="486" text-anchor="middle" font-size="8.5" fill="#94a3b8">config.yaml + prompt</text>
+  <text x="422" y="496" text-anchor="middle" font-size="8.5" fill="#94a3b8">+ extensions</text>
+
+  <text x="80" y="524" font-size="9" fill="#6b7280" font-style="italic">Each community = independent namespace. No cross-community routing.</text>
+
+  <!-- Agent Stack y=406..516 -->
+  <rect x="540" y="406" width="230" height="110" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="560" y="426" font-size="12" font-weight="600" fill="#065f46">Agent Stack</text>
+  <rect x="556" y="436" width="200" height="24" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="656" y="453" text-anchor="middle" font-size="10" fill="#166534">LangGraph (state machine)</text>
+  <rect x="556" y="466" width="200" height="24" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="656" y="483" text-anchor="middle" font-size="10" fill="#166534">LiteLLM (provider abstraction)</text>
+  <rect x="556" y="496" width="200" height="12" rx="3" fill="#f0fdf9" stroke="#d1fae5" stroke-width="0.5"/>
+  <text x="656" y="505" text-anchor="middle" font-size="8" fill="#6b7280">Prompt caching (Anthropic)</text>
+
+  <!-- Tool System y=406..516 -->
+  <rect x="790" y="406" width="240" height="110" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="810" y="426" font-size="12" font-weight="600" fill="#065f46">Tool System</text>
+  <rect x="806" y="436" width="105" height="22" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="858" y="451" text-anchor="middle" font-size="9" fill="#166534">Doc Retrieval</text>
+  <rect x="916" y="436" width="100" height="22" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="966" y="451" text-anchor="middle" font-size="9" fill="#166534">Knowledge Search</text>
+  <rect x="806" y="464" width="105" height="22" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="858" y="479" text-anchor="middle" font-size="9" fill="#166534">HED Validation</text>
+  <rect x="916" y="464" width="100" height="22" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="966" y="479" text-anchor="middle" font-size="9" fill="#166534">GitHub Search</text>
+  <rect x="806" y="492" width="210" height="16" rx="3" fill="#f0fdf9" stroke="#d1fae5" stroke-width="0.5"/>
+  <text x="911" y="503" text-anchor="middle" font-size="8" fill="#6b7280">Per-community tool config (YAML extensions)</text>
+
+  <!-- Bottom row inside server: y=540..588 -->
+  <rect x="60" y="540" width="200" height="48" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="160" y="561" text-anchor="middle" font-size="11" font-weight="600" fill="#065f46">Session Manager</text>
+  <text x="160" y="575" text-anchor="middle" font-size="9" fill="#64748b">In-memory (single instance)</text>
+
+  <rect x="280" y="540" width="200" height="48" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="380" y="561" text-anchor="middle" font-size="11" font-weight="600" fill="#065f46">YAML Registry</text>
+  <text x="380" y="575" text-anchor="middle" font-size="9" fill="#64748b">src/assistants/*/config.yaml</text>
+
+  <rect x="500" y="540" width="200" height="48" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="600" y="561" text-anchor="middle" font-size="11" font-weight="600" fill="#065f46">Knowledge Sync</text>
+  <text x="600" y="575" text-anchor="middle" font-size="9" fill="#64748b">GitHub Issues/PRs ingestion</text>
+
+  <rect x="720" y="540" width="160" height="48" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="800" y="561" text-anchor="middle" font-size="11" font-weight="600" fill="#065f46">Settings</text>
+  <text x="800" y="575" text-anchor="middle" font-size="9" fill="#64748b">pydantic-settings (.env)</text>
+
+  <rect x="900" y="540" width="130" height="48" rx="8" fill="white" stroke="#6ee7b7" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="965" y="561" text-anchor="middle" font-size="11" font-weight="600" fill="#065f46">Model Selection</text>
+  <text x="965" y="575" text-anchor="middle" font-size="9" fill="#64748b">BYOK > community > platform</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ROUTING CORRIDOR y=610..665 (invisible gap for arrows) -->
+  <!-- ═══════════════════════════════════════════ -->
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- DATA LAYER  y=670..770 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="30" y="670" width="500" height="100" rx="10" fill="url(#dataGrad)" stroke="#c4b5fd" stroke-width="1" filter="url(#shadow)"/>
+  <text x="50" y="690" font-size="11" font-weight="600" fill="#5b21b6" letter-spacing="1">DATA (inside container)</text>
+
+  <rect x="60" y="700" width="210" height="56" rx="8" fill="white" stroke="#c4b5fd" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="165" y="722" text-anchor="middle" font-size="13" font-weight="600" fill="#5b21b6">SQLite + FTS5</text>
+  <text x="165" y="738" text-anchor="middle" font-size="10" fill="#64748b">/app/data/knowledge/{id}.db</text>
+  <text x="165" y="750" text-anchor="middle" font-size="9" fill="#94a3b8">Issues, PRs, docs (BM25 ranking)</text>
+
+  <rect x="290" y="700" width="220" height="56" rx="8" fill="white" stroke="#c4b5fd" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="400" y="722" text-anchor="middle" font-size="13" font-weight="600" fill="#5b21b6">Community Configs</text>
+  <text x="400" y="738" text-anchor="middle" font-size="10" fill="#64748b">YAML configs, system prompts</text>
+  <text x="400" y="750" text-anchor="middle" font-size="9" fill="#94a3b8">tools, extensions, examples</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- EXTERNAL SERVICES  y=670..770 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="550" y="670" width="520" height="100" rx="10" fill="url(#extGrad)" stroke="#fca5a5" stroke-width="1" filter="url(#shadow)"/>
+  <text x="570" y="690" font-size="11" font-weight="600" fill="#991b1b" letter-spacing="1">EXTERNAL SERVICES</text>
+
+  <rect x="570" y="700" width="140" height="56" rx="8" fill="white" stroke="#fca5a5" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="640" y="722" text-anchor="middle" font-size="12" font-weight="600" fill="#991b1b">OpenRouter</text>
+  <text x="640" y="736" text-anchor="middle" font-size="9" fill="#64748b">LLM providers</text>
+  <text x="640" y="748" text-anchor="middle" font-size="8.5" fill="#94a3b8">Qwen, Claude, GPT, etc.</text>
+
+  <rect x="720" y="700" width="110" height="56" rx="8" fill="white" stroke="#fca5a5" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="775" y="722" text-anchor="middle" font-size="12" font-weight="600" fill="#991b1b">LangFuse</text>
+  <text x="775" y="736" text-anchor="middle" font-size="9" fill="#64748b">Observability</text>
+  <text x="775" y="748" text-anchor="middle" font-size="8.5" fill="#94a3b8">Traces, cost, quality</text>
+
+  <rect x="840" y="700" width="110" height="56" rx="8" fill="white" stroke="#fca5a5" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="895" y="722" text-anchor="middle" font-size="12" font-weight="600" fill="#991b1b">GitHub API</text>
+  <text x="895" y="736" text-anchor="middle" font-size="9" fill="#64748b">Issues, PRs</text>
+  <text x="895" y="748" text-anchor="middle" font-size="8.5" fill="#94a3b8">Knowledge sync source</text>
+
+  <rect x="960" y="700" width="95" height="56" rx="8" fill="white" stroke="#fca5a5" stroke-width="1" filter="url(#shadowLight)"/>
+  <text x="1007" y="722" text-anchor="middle" font-size="12" font-weight="600" fill="#991b1b">hedtools.org</text>
+  <text x="1007" y="736" text-anchor="middle" font-size="9" fill="#64748b">HED Validation</text>
+  <text x="1007" y="748" text-anchor="middle" font-size="8.5" fill="#94a3b8">REST API</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- CI/CD bar  y=790..846 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="30" y="790" width="1040" height="56" rx="10" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" filter="url(#shadow)"/>
+  <text x="50" y="810" font-size="11" font-weight="600" fill="#475569" letter-spacing="1">CI/CD PIPELINE</text>
+
+  <rect x="60" y="820" width="160" height="20" rx="4" fill="#e2e8f0" stroke="#cbd5e1" stroke-width="0.5"/>
+  <text x="140" y="834" text-anchor="middle" font-size="9" fill="#475569">GitHub Actions (build/test)</text>
+  <text x="230" y="834" font-size="10" fill="#94a3b8">-></text>
+  <rect x="248" y="820" width="140" height="20" rx="4" fill="#e2e8f0" stroke="#cbd5e1" stroke-width="0.5"/>
+  <text x="318" y="834" text-anchor="middle" font-size="9" fill="#475569">GHCR Docker Image</text>
+  <text x="398" y="834" font-size="10" fill="#94a3b8">-></text>
+  <rect x="416" y="820" width="120" height="20" rx="4" fill="#e2e8f0" stroke="#cbd5e1" stroke-width="0.5"/>
+  <text x="476" y="834" text-anchor="middle" font-size="9" fill="#475569">SSH deploy script</text>
+  <text x="546" y="834" font-size="10" fill="#94a3b8">-></text>
+  <rect x="564" y="820" width="160" height="20" rx="4" fill="#e2e8f0" stroke="#cbd5e1" stroke-width="0.5"/>
+  <text x="644" y="834" text-anchor="middle" font-size="9" fill="#475569">docker pull + restart</text>
+  <rect x="770" y="817" width="130" height="24" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.5"/>
+  <text x="835" y="833" text-anchor="middle" font-size="9" fill="#1e40af">develop -> :dev tag</text>
+  <rect x="910" y="817" width="140" height="24" rx="4" fill="#dcfce7" stroke="#86efac" stroke-width="0.5"/>
+  <text x="980" y="833" text-anchor="middle" font-size="9" fill="#166534">main -> :latest + release</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- Legend  y=864..920 -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="30" y="864" width="1040" height="56" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="50" y="882" font-size="10" font-weight="600" fill="#475569">Legend:</text>
+
+  <line x1="100" y1="879" x2="130" y2="879" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="136" y="883" font-size="9" fill="#64748b">Direct connection</text>
+
+  <line x1="250" y1="879" x2="280" y2="879" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowRed)"/>
+  <text x="286" y="883" font-size="9" fill="#64748b">External API call</text>
+
+  <line x1="400" y1="879" x2="430" y2="879" stroke="#a78bfa" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowPurple)"/>
+  <text x="436" y="883" font-size="9" fill="#64748b">Data read/write</text>
+
+  <rect x="555" y="873" width="14" height="14" rx="3" fill="url(#clientGrad)" stroke="#93c5fd" stroke-width="0.5"/>
+  <text x="575" y="884" font-size="9" fill="#64748b">Clients</text>
+  <rect x="620" y="873" width="14" height="14" rx="3" fill="url(#edgeGrad)" stroke="#fbbf24" stroke-width="0.5"/>
+  <text x="640" y="884" font-size="9" fill="#64748b">Edge</text>
+  <rect x="680" y="873" width="14" height="14" rx="3" fill="url(#serverGrad)" stroke="#6ee7b7" stroke-width="0.5"/>
+  <text x="700" y="884" font-size="9" fill="#64748b">Server</text>
+  <rect x="750" y="873" width="14" height="14" rx="3" fill="url(#dataGrad)" stroke="#c4b5fd" stroke-width="0.5"/>
+  <text x="770" y="884" font-size="9" fill="#64748b">Data</text>
+  <rect x="810" y="873" width="14" height="14" rx="3" fill="url(#extGrad)" stroke="#fca5a5" stroke-width="0.5"/>
+  <text x="830" y="884" font-size="9" fill="#64748b">External</text>
+
+  <text x="50" y="908" font-size="9" fill="#94a3b8">Single-instance deployment. No inter-community routing; each community is an independent namespace with its own agent, tools, and knowledge base.</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ARROWS - All use orthogonal (right-angle) routing -->
+  <!-- ═══════════════════════════════════════════ -->
+
+  <!-- === CLIENTS -> EDGE LAYER === -->
+
+  <!-- CLI -> Apache (straight down, jog right) -->
+  <path d="M 150,158 L 150,186 L 440,186 L 440,222"
+        fill="none" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#arrow)"/>
+  <text x="280" y="183" font-size="8" fill="#94a3b8">HTTPS</text>
+
+  <!-- Web Widget -> Cloudflare Pages (hosted there) -->
+  <path d="M 340,158 L 340,186 L 180,186 L 180,222"
+        fill="none" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#arrow)"/>
+  <text x="240" y="183" font-size="8" fill="#94a3b8">hosted</text>
+
+  <!-- Web Widget -> Apache (API calls) -->
+  <path d="M 420,158 L 420,186 L 530,186 L 530,222"
+        fill="none" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#arrow)"/>
+  <text x="462" y="183" font-size="8" fill="#94a3b8">API calls</text>
+
+  <!-- API Clients -> Apache -->
+  <path d="M 610,158 L 610,186 L 580,186 L 580,222"
+        fill="none" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#arrow)"/>
+
+  <!-- === EDGE -> SERVER === -->
+
+  <!-- Apache -> FastAPI (straight down) -->
+  <path d="M 530,270 L 530,334"
+        fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="536" y="304" font-size="8" fill="#94a3b8">HTTP</text>
+
+  <!-- === WITHIN SERVER (horizontal connections) === -->
+
+  <!-- Community Routers -> Agent Stack (horizontal) -->
+  <path d="M 520,461 L 540,461"
+        fill="none" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#arrow)"/>
+
+  <!-- Agent Stack -> Tools (horizontal) -->
+  <path d="M 770,461 L 790,461"
+        fill="none" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#arrow)"/>
+  <text x="776" y="455" font-size="8" fill="#94a3b8">calls</text>
+
+  <!-- === SERVER -> EXTERNAL SERVICES (orthogonal routing through corridor) === -->
+
+  <!-- Agent Stack -> OpenRouter (LLM calls) -->
+  <!-- Exit bottom of Agent Stack, go down to corridor lane 1, go right to OpenRouter, go down -->
+  <path d="M 620,516 L 620,625 L 640,625 L 640,700"
+        fill="none" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowRed)"/>
+  <text x="576" y="622" font-size="8.5" fill="#f87171">LLM calls</text>
+
+  <!-- Agent Stack -> LangFuse (traces) -->
+  <!-- Exit bottom of Agent Stack right side, go down to corridor lane 2, go right to LangFuse, go down -->
+  <path d="M 690,516 L 690,635 L 775,635 L 775,700"
+        fill="none" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowRed)"/>
+  <text x="710" y="632" font-size="8.5" fill="#f87171">traces</text>
+
+  <!-- Tools -> hedtools.org (HED Validation) -->
+  <!-- Exit bottom of Tools right side, go down to corridor lane 3, go right to HED, go down -->
+  <path d="M 1007,516 L 1007,700"
+        fill="none" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowRed)"/>
+  <text x="1013" y="622" font-size="8.5" fill="#f87171">validate</text>
+
+  <!-- Tools -> GitHub API (GitHub Search tool) -->
+  <!-- Exit bottom of Tools, go down to corridor lane 4, go right to GitHub API, go down -->
+  <path d="M 950,516 L 950,645 L 895,645 L 895,700"
+        fill="none" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowRed)"/>
+  <text x="902" y="642" font-size="8.5" fill="#f87171">search</text>
+
+  <!-- === SERVER -> DATA LAYER (orthogonal routing through corridor) === -->
+
+  <!-- Tools (Knowledge Search) -> SQLite -->
+  <!-- Exit bottom of Tools left side, go down to corridor lane 5, go left all the way to SQLite, go down -->
+  <path d="M 840,516 L 840,655 L 165,655 L 165,700"
+        fill="none" stroke="#a78bfa" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowPurple)"/>
+  <text x="480" y="652" font-size="8.5" fill="#a78bfa">knowledge query (FTS5)</text>
+
+  <!-- Knowledge Sync -> SQLite -->
+  <!-- Exit bottom of Knowledge Sync left side, go down to corridor lane 6, go left to SQLite, go down -->
+  <path d="M 560,588 L 560,645 L 200,645 L 200,700"
+        fill="none" stroke="#a78bfa" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowPurple)"/>
+  <text x="300" y="642" font-size="8.5" fill="#a78bfa">write ingested data</text>
+
+  <!-- Knowledge Sync -> GitHub API (source of ingested data) -->
+  <!-- Exit bottom of Knowledge Sync right side, go down to corridor lane 7, go right to GitHub API, go down -->
+  <path d="M 650,588 L 650,620 L 870,620 L 870,700"
+        fill="none" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrowRed)"/>
+  <text x="710" y="617" font-size="8.5" fill="#f87171">fetch issues/PRs</text>
+
+</svg>

--- a/docs/osa/architecture-overview.svg
+++ b/docs/osa/architecture-overview.svg
@@ -1,0 +1,153 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" font-family="'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc"/>
+      <stop offset="100%" stop-color="#f1f5f9"/>
+    </linearGradient>
+    <filter id="shadow" x="-3%" y="-3%" width="106%" height="110%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.1"/>
+    </filter>
+    <filter id="shadowSm" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-opacity="0.07"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrowDark" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="620" fill="url(#bgGrad)" rx="12"/>
+
+  <!-- Title -->
+  <text x="450" y="36" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">Open Science Assistant (OSA)</text>
+  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#64748b">AI-powered research assistant platform for open science communities</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ROW 1: Users -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="300" y="78" width="300" height="52" rx="26" fill="#1e40af" filter="url(#shadow)"/>
+  <text x="450" y="100" text-anchor="middle" font-size="14" font-weight="600" fill="white">Researchers</text>
+  <text x="450" y="116" text-anchor="middle" font-size="10" fill="#bfdbfe">HED, BIDS, EEGLAB, MNE communities</text>
+
+  <!-- Arrow: Users -> Interfaces -->
+  <path d="M 450,130 L 450,155" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ROW 2: Client Interfaces -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="80" y="160" width="740" height="70" rx="10" fill="#eff6ff" stroke="#93c5fd" stroke-width="1" filter="url(#shadow)"/>
+  <text x="100" y="180" font-size="10" font-weight="600" fill="#1e40af" letter-spacing="0.5">CLIENT INTERFACES</text>
+
+  <rect x="100" y="192" width="150" height="28" rx="6" fill="white" stroke="#93c5fd" stroke-width="1" filter="url(#shadowSm)"/>
+  <text x="175" y="211" text-anchor="middle" font-size="11" font-weight="500" fill="#1e3a5f">CLI (pip install)</text>
+
+  <rect x="270" y="192" width="190" height="28" rx="6" fill="white" stroke="#93c5fd" stroke-width="1" filter="url(#shadowSm)"/>
+  <text x="365" y="211" text-anchor="middle" font-size="11" font-weight="500" fill="#1e3a5f">Web Chat Widget (JS)</text>
+
+  <rect x="480" y="192" width="150" height="28" rx="6" fill="white" stroke="#93c5fd" stroke-width="1" filter="url(#shadowSm)"/>
+  <text x="555" y="211" text-anchor="middle" font-size="11" font-weight="500" fill="#1e3a5f">REST API</text>
+
+  <rect x="650" y="192" width="150" height="28" rx="6" fill="#dbeafe" stroke="#93c5fd" stroke-width="1"/>
+  <text x="725" y="211" text-anchor="middle" font-size="10" font-weight="500" fill="#1e40af">BYOK + API Keys</text>
+
+  <!-- Arrow: Interfaces -> Edge -->
+  <path d="M 450,230 L 450,253" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="460" y="246" font-size="8" fill="#94a3b8">HTTPS</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ROW 3: Edge -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="200" y="258" width="500" height="36" rx="8" fill="#fef3c7" stroke="#fbbf24" stroke-width="1" filter="url(#shadow)"/>
+  <text x="450" y="281" text-anchor="middle" font-size="11" font-weight="600" fill="#92400e">Cloudflare Pages + Apache Reverse Proxy (api.osc.earth) + CORS</text>
+
+  <!-- Arrow: Edge -> Platform -->
+  <path d="M 450,294 L 450,317" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ROW 4: OSA Platform (main box) -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="80" y="322" width="740" height="148" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="100" y="344" font-size="11" font-weight="700" fill="#065f46" letter-spacing="0.5">OSA PLATFORM</text>
+  <text x="260" y="344" font-size="9" fill="#065f46">(FastAPI + LangGraph + Docker)</text>
+
+  <!-- Community routing boxes -->
+  <text x="100" y="366" font-size="10" font-weight="600" fill="#065f46">Community-based routing (each community = independent agent + tools + knowledge):</text>
+
+  <rect x="100" y="376" width="145" height="80" rx="8" fill="white" stroke="#86efac" stroke-width="1" filter="url(#shadowSm)"/>
+  <text x="172" y="398" text-anchor="middle" font-size="13" font-weight="700" fill="#166534">/hed/</text>
+  <text x="172" y="414" text-anchor="middle" font-size="9" fill="#64748b">Annotations, validation</text>
+  <text x="172" y="428" text-anchor="middle" font-size="9" fill="#64748b">Doc retrieval, HED tools</text>
+  <text x="172" y="442" text-anchor="middle" font-size="8" fill="#a3a3a3">hedtags.org integration</text>
+
+  <rect x="260" y="376" width="145" height="80" rx="8" fill="white" stroke="#86efac" stroke-width="1" filter="url(#shadowSm)"/>
+  <text x="332" y="398" text-anchor="middle" font-size="13" font-weight="700" fill="#166534">/eeglab/</text>
+  <text x="332" y="414" text-anchor="middle" font-size="9" fill="#64748b">EEG analysis, MATLAB</text>
+  <text x="332" y="428" text-anchor="middle" font-size="9" fill="#64748b">Doc retrieval, search</text>
+  <text x="332" y="442" text-anchor="middle" font-size="8" fill="#a3a3a3">sccn.ucsd.edu docs</text>
+
+  <rect x="420" y="376" width="145" height="80" rx="8" fill="white" stroke="#86efac" stroke-width="1" filter="url(#shadowSm)"/>
+  <text x="492" y="398" text-anchor="middle" font-size="13" font-weight="700" fill="#166534">/mne/</text>
+  <text x="492" y="414" text-anchor="middle" font-size="9" fill="#64748b">M/EEG analysis, Python</text>
+  <text x="492" y="428" text-anchor="middle" font-size="9" fill="#64748b">Doc retrieval, search</text>
+  <text x="492" y="442" text-anchor="middle" font-size="8" fill="#a3a3a3">mne.tools docs</text>
+
+  <!-- Ellipsis for more communities -->
+  <rect x="580" y="376" width="80" height="80" rx="8" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1" stroke-dasharray="4,2"/>
+  <text x="620" y="416" text-anchor="middle" font-size="18" fill="#86efac">...</text>
+  <text x="620" y="436" text-anchor="middle" font-size="8" fill="#94a3b8">add via YAML</text>
+
+  <!-- Shared infrastructure note -->
+  <rect x="674" y="376" width="132" height="80" rx="8" fill="#f0fdf4" stroke="#d1fae5" stroke-width="1"/>
+  <text x="740" y="394" text-anchor="middle" font-size="9" font-weight="600" fill="#065f46">Shared infra</text>
+  <text x="740" y="410" text-anchor="middle" font-size="8.5" fill="#64748b">LiteLLM (LLM)</text>
+  <text x="740" y="423" text-anchor="middle" font-size="8.5" fill="#64748b">SQLite + FTS5 (data)</text>
+  <text x="740" y="436" text-anchor="middle" font-size="8.5" fill="#64748b">Session mgmt</text>
+  <text x="740" y="449" text-anchor="middle" font-size="8.5" fill="#64748b">SSE streaming</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ROW 5: External Services + Data -->
+  <!-- ═══════════════════════════════════════════ -->
+
+  <!-- Arrows from platform down to services -->
+  <!-- Platform -> OpenRouter -->
+  <path d="M 200,470 L 200,500 L 140,500 L 140,520" fill="none" stroke="#64748b" stroke-width="1.3" marker-end="url(#arrowDark)"/>
+  <text x="146" y="497" font-size="8" fill="#64748b">LLM</text>
+
+  <!-- Platform -> LangFuse -->
+  <path d="M 350,470 L 350,500 L 330,500 L 330,520" fill="none" stroke="#64748b" stroke-width="1.3" marker-end="url(#arrowDark)"/>
+  <text x="356" y="497" font-size="8" fill="#64748b">traces</text>
+
+  <!-- Platform -> GitHub -->
+  <path d="M 500,470 L 500,500 L 520,500 L 520,520" fill="none" stroke="#64748b" stroke-width="1.3" marker-end="url(#arrowDark)"/>
+  <text x="506" y="497" font-size="8" fill="#64748b">sync</text>
+
+  <!-- Platform -> hedtools -->
+  <path d="M 650,470 L 650,500 L 700,500 L 700,520" fill="none" stroke="#64748b" stroke-width="1.3" marker-end="url(#arrowDark)"/>
+  <text x="656" y="497" font-size="8" fill="#64748b">validate</text>
+
+  <!-- Service boxes -->
+  <rect x="60" y="524" width="180" height="52" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1" filter="url(#shadow)"/>
+  <text x="150" y="546" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">OpenRouter</text>
+  <text x="150" y="562" text-anchor="middle" font-size="9" fill="#94a3b8">Qwen, Claude, GPT, Gemini</text>
+
+  <rect x="260" y="524" width="140" height="52" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1" filter="url(#shadow)"/>
+  <text x="330" y="546" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">LangFuse</text>
+  <text x="330" y="562" text-anchor="middle" font-size="9" fill="#94a3b8">Observability, cost</text>
+
+  <rect x="420" y="524" width="200" height="52" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1" filter="url(#shadow)"/>
+  <text x="520" y="546" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">GitHub API</text>
+  <text x="520" y="562" text-anchor="middle" font-size="9" fill="#94a3b8">Issues, PRs (knowledge source)</text>
+
+  <rect x="640" y="524" width="160" height="52" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1" filter="url(#shadow)"/>
+  <text x="720" y="546" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">hedtools.org</text>
+  <text x="720" y="562" text-anchor="middle" font-size="9" fill="#94a3b8">HED validation API</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- Footer note -->
+  <!-- ═══════════════════════════════════════════ -->
+  <text x="450" y="600" text-anchor="middle" font-size="10" fill="#94a3b8">Single-instance lab server deployment. No inter-community routing. Communities are added via YAML config, no code changes needed.</text>
+
+</svg>

--- a/docs/osa/architecture.md
+++ b/docs/osa/architecture.md
@@ -1,460 +1,50 @@
-# Architecture
+# Architecture Overview
 
-This document describes the system architecture of OSA.
+OSA is a single-instance AI assistant platform that serves multiple research communities from one deployment. Each community gets its own independent namespace with a dedicated agent, tools, and knowledge base.
 
----
-
-## System Overview
-
-```mermaid
-flowchart TB
-    subgraph Users["User Interfaces"]
-        CLI[("CLI<br/>(Typer)")]
-        API[("REST API<br/>(FastAPI)")]
-        Web[("Web Frontend<br/>(Future)")]
-    end
-
-    subgraph Core["Core Platform"]
-        Router{{"Router Agent"}}
-        State[("State Manager<br/>(LangGraph)")]
-        Telemetry[("Telemetry<br/>Service")]
-    end
-
-    subgraph Assistants["Specialist Assistants"]
-        HED["HED Assistant"]
-        BIDS["BIDS Assistant"]
-        EEGLAB["EEGLAB Assistant"]
-        General["General Assistant"]
-    end
-
-    subgraph Tools["Tool System"]
-        DocRetrieval["Document<br/>Retrieval"]
-        Validation["Validation<br/>API Integrations"]
-        Search["Knowledge<br/>Search"]
-    end
-
-    subgraph Knowledge["Knowledge Sources"]
-        GitHub[("GitHub<br/>Issues/PRs")]
-        OpenALEX[("OpenALEX<br/>Papers")]
-        Discourse[("Discourse<br/>Forums")]
-        MailingLists[("Mailing<br/>Lists")]
-        Docs[("Documentation<br/>Sites")]
-    end
-
-    subgraph Observability["Observability"]
-        LangFuse[("LangFuse<br/>Tracing")]
-        Feedback[("Feedback<br/>System")]
-        DB[("PostgreSQL<br/>Storage")]
-    end
-
-    CLI --> API
-    Web --> API
-    API --> Router
-    Router --> State
-    State --> Telemetry
-
-    Router --> HED
-    Router --> BIDS
-    Router --> EEGLAB
-    Router --> General
-
-    HED --> Tools
-    BIDS --> Tools
-    EEGLAB --> Tools
-    General --> Tools
-
-    Tools --> Knowledge
-
-    DocRetrieval --> Docs
-    Search --> GitHub
-    Search --> OpenALEX
-    Search --> Discourse
-    Search --> MailingLists
-
-    Telemetry --> LangFuse
-    Telemetry --> DB
-    API --> Feedback
-    Feedback --> DB
-```
+<figure markdown="span">
+  ![OSA Architecture Overview](architecture-overview.svg){ width="100%" }
+  <figcaption>High-level view of the OSA platform</figcaption>
+</figure>
 
 ---
 
-## Request Flow
+## Key Design Decisions
 
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant API as FastAPI
-    participant R as Router Agent
-    participant A as Specialist Assistant
-    participant T as Tools
-    participant K as Knowledge Sources
-    participant O as Observability
+### Community-based routing, not a supervisor agent
 
-    U->>API: Query
-    API->>O: Start Session
-    API->>R: Route Query
+Each community (HED, EEGLAB, MNE, etc.) is an **independent namespace** at the API level:
 
-    R->>R: Analyze Intent
-    R->>A: Delegate to Specialist
-
-    loop Tool Calls
-        A->>T: Request Information
-        T->>K: Fetch Data
-        K-->>T: Return Data
-        T-->>A: Tool Result
-    end
-
-    A->>A: Generate Response
-    A-->>R: Response
-    R-->>API: Final Response
-
-    API->>O: Log Session
-    API-->>U: Stream Response
+```
+/hed/ask       - Ask the HED assistant
+/eeglab/chat   - Chat with the EEGLAB assistant
+/mne/ask       - Ask the MNE assistant
 ```
 
----
+There is no router or supervisor agent that dispatches queries between communities. The user (or widget) selects a community explicitly, and each community has its own:
 
-## Assistant Routing (Supervisor Pattern)
+- **System prompt** tailored to the domain
+- **Tools** configured via YAML extensions
+- **Knowledge base** (SQLite + FTS5, synced from GitHub)
+- **LangGraph agent** running the conversation loop
 
-```mermaid
-flowchart TD
-    subgraph Input
-        Query["User Query"]
-    end
+### Simple infrastructure
 
-    subgraph Router["Router Agent"]
-        Analyze["Analyze Query Intent"]
-        Rules{"Rule-Based<br/>Match?"}
-        LLM["LLM Classification"]
-    end
+OSA targets small research communities running on lab servers, not large-scale cloud deployments:
 
-    subgraph Specialists
-        HED["HED Assistant<br/><i>Annotations, Events</i>"]
-        BIDS["BIDS Assistant<br/><i>Datasets, Organization</i>"]
-        EEGLAB["EEGLAB Assistant<br/><i>EEG Analysis, MATLAB</i>"]
-        General["General Assistant<br/><i>Cross-cutting, Meta</i>"]
-    end
+| Choice | Why |
+|--------|-----|
+| **Single FastAPI instance** | No need for horizontal scaling |
+| **SQLite + FTS5** | No external database server needed; full-text search with BM25 ranking |
+| **In-memory sessions** | Single instance means no shared state needed |
+| **Docker** | Reproducible deployment, easy updates |
+| **OpenRouter** | Single API for multiple LLM providers (Qwen, Claude, GPT, etc.) |
 
-    subgraph Context
-        State["Shared State"]
-        History["Conversation History"]
-    end
+### Adding a community requires no code changes
 
-    Query --> Analyze
-    Analyze --> Rules
+Communities are defined entirely in YAML configuration files. Adding a new community means creating a `config.yaml` with the community's identity, system prompt, tools, and knowledge sources. The API routes are generated dynamically at startup.
 
-    Rules -->|"'HED', 'annotation'"| HED
-    Rules -->|"'BIDS', 'dataset'"| BIDS
-    Rules -->|"'EEGLAB', 'EEG'"| EEGLAB
-    Rules -->|"No match"| LLM
-
-    LLM --> HED
-    LLM --> BIDS
-    LLM --> EEGLAB
-    LLM --> General
-
-    HED <--> State
-    BIDS <--> State
-    EEGLAB <--> State
-    General <--> State
-
-    State <--> History
-```
-
----
-
-## Tool Execution Pipeline
-
-```mermaid
-flowchart LR
-    subgraph Assistant
-        A["Assistant Agent"]
-        Decision{"Tool<br/>Needed?"}
-    end
-
-    subgraph ToolSystem["Tool System"]
-        Registry["Tool Registry"]
-        Permission{"Requires<br/>Permission?"}
-        Execute["Execute Tool"]
-    end
-
-    subgraph Sources["Data Sources"]
-        direction TB
-        S1["GitHub API"]
-        S2["OpenALEX API"]
-        S3["Discourse API"]
-        S4["Doc Fetcher"]
-        S5["Validators"]
-    end
-
-    subgraph Output
-        Result["Tool Result"]
-        Cache["Result Cache"]
-    end
-
-    A --> Decision
-    Decision -->|"Yes"| Registry
-    Decision -->|"No"| A
-
-    Registry --> Permission
-    Permission -->|"Yes"| User["User Approval"]
-    Permission -->|"No"| Execute
-    User -->|"Approved"| Execute
-    User -->|"Denied"| A
-
-    Execute --> S1
-    Execute --> S2
-    Execute --> S3
-    Execute --> S4
-    Execute --> S5
-
-    S1 --> Result
-    S2 --> Result
-    S3 --> Result
-    S4 --> Result
-    S5 --> Result
-
-    Result --> Cache
-    Result --> A
-```
-
----
-
-## Knowledge Source Integration
-
-```mermaid
-flowchart TB
-    subgraph Query["Query Processing"]
-        Q["Search Query"]
-        Expand["Query Expansion"]
-    end
-
-    subgraph Sources["Knowledge Sources"]
-        subgraph GitHub["GitHub"]
-            GH_Issues["Issues"]
-            GH_PRs["Pull Requests"]
-            GH_Disc["Discussions"]
-        end
-
-        subgraph Academic["Academic"]
-            OA["OpenALEX<br/>Papers"]
-            Citations["Citations"]
-        end
-
-        subgraph Community["Community"]
-            NS["Neurostars<br/>Forum"]
-            MNE["MNE Forum"]
-            ML["Mailing Lists<br/>(EEGLAB, etc.)"]
-        end
-
-        subgraph Docs["Documentation"]
-            HED_Docs["HED Specs"]
-            BIDS_Docs["BIDS Specs"]
-            EEG_Docs["EEGLAB Docs"]
-        end
-    end
-
-    subgraph Processing["Result Processing"]
-        Merge["Merge Results"]
-        Rank["Relevance Ranking"]
-        Dedupe["Deduplication"]
-    end
-
-    subgraph Output["Output"]
-        Context["Retrieved Context"]
-    end
-
-    Q --> Expand
-    Expand --> GitHub
-    Expand --> Academic
-    Expand --> Community
-    Expand --> Docs
-
-    GH_Issues --> Merge
-    GH_PRs --> Merge
-    GH_Disc --> Merge
-    OA --> Merge
-    Citations --> Merge
-    NS --> Merge
-    MNE --> Merge
-    ML --> Merge
-    HED_Docs --> Merge
-    BIDS_Docs --> Merge
-    EEG_Docs --> Merge
-
-    Merge --> Rank
-    Rank --> Dedupe
-    Dedupe --> Context
-```
-
----
-
-## Feedback Triage System
-
-```mermaid
-flowchart TD
-    subgraph Input["Feedback Input"]
-        User["User Feedback"]
-        Session["Session Context"]
-    end
-
-    subgraph Triage["Triage Agent"]
-        Classify["Classify Feedback"]
-        Severity{"Severity?"}
-        Similar["Find Similar Issues"]
-        Match{"Match<br/>Found?"}
-    end
-
-    subgraph Actions["Actions"]
-        Archive["Archive for<br/>Manual Review"]
-        Comment["Add Comment to<br/>Existing Issue"]
-        Create["Create New<br/>GitHub Issue"]
-    end
-
-    subgraph Storage["Storage"]
-        JSONL["Feedback JSONL"]
-        DB["Analytics DB"]
-        GH["GitHub Issues"]
-    end
-
-    User --> Classify
-    Session --> Classify
-
-    Classify --> Severity
-
-    Severity -->|"Low"| Archive
-    Severity -->|"Medium/High"| Similar
-
-    Similar --> Match
-
-    Match -->|"Yes (>80%)"| Comment
-    Match -->|"No"| Severity2{"High Severity<br/>Bug/Feature?"}
-
-    Severity2 -->|"Yes"| Create
-    Severity2 -->|"No"| Archive
-
-    Archive --> JSONL
-    Archive --> DB
-    Comment --> GH
-    Create --> GH
-
-    style Archive fill:#f9f,stroke:#333
-    style Comment fill:#ff9,stroke:#333
-    style Create fill:#9f9,stroke:#333
-```
-
----
-
-## Telemetry and Session Recording
-
-```mermaid
-flowchart LR
-    subgraph Session["Chat Session"]
-        Start["Session Start"]
-        Msg["Messages"]
-        Tools["Tool Calls"]
-        End["Session End"]
-    end
-
-    subgraph Capture["Telemetry Capture"]
-        Meta["Metadata<br/><i>user, model, assistant</i>"]
-        Content["Content<br/><i>messages, responses</i>"]
-        Usage["Usage<br/><i>tokens, cost</i>"]
-    end
-
-    subgraph Storage["Storage Layer"]
-        PG[("PostgreSQL")]
-        LF[("LangFuse")]
-    end
-
-    subgraph Analytics["Analytics"]
-        Cost["Cost Tracking"]
-        Quality["Quality Metrics"]
-        Export["Training Data<br/>Export"]
-    end
-
-    Start --> Meta
-    Msg --> Content
-    Tools --> Content
-    End --> Usage
-
-    Meta --> PG
-    Content --> PG
-    Usage --> PG
-
-    Meta --> LF
-    Content --> LF
-    Usage --> LF
-
-    PG --> Cost
-    PG --> Quality
-    PG --> Export
-
-    LF --> Cost
-    LF --> Quality
-```
-
----
-
-## Deployment Architecture
-
-```mermaid
-flowchart TB
-    subgraph Client["Client Layer"]
-        CLI["CLI Tool"]
-        WebApp["Web Application"]
-        ExtAPI["External API Clients"]
-    end
-
-    subgraph Edge["Edge/CDN"]
-        LB["Load Balancer"]
-    end
-
-    subgraph API["API Layer"]
-        FastAPI1["FastAPI Instance 1"]
-        FastAPI2["FastAPI Instance 2"]
-        FastAPIN["FastAPI Instance N"]
-    end
-
-    subgraph Workers["Background Workers"]
-        Feedback["Feedback Processor"]
-        Index["Knowledge Indexer"]
-    end
-
-    subgraph Data["Data Layer"]
-        PG[("PostgreSQL<br/><i>State, Telemetry</i>")]
-        Redis[("Redis<br/><i>Cache, Sessions</i>")]
-        VectorDB[("Vector Store<br/><i>Embeddings</i>")]
-    end
-
-    subgraph External["External Services"]
-        LLM["LLM Providers<br/><i>OpenRouter</i>"]
-        LangFuse["LangFuse<br/><i>Observability</i>"]
-        GitHub["GitHub API"]
-    end
-
-    CLI --> LB
-    WebApp --> LB
-    ExtAPI --> LB
-
-    LB --> FastAPI1
-    LB --> FastAPI2
-    LB --> FastAPIN
-
-    FastAPI1 --> PG
-    FastAPI1 --> Redis
-    FastAPI1 --> VectorDB
-    FastAPI1 --> LLM
-    FastAPI1 --> LangFuse
-
-    FastAPI2 --> PG
-    FastAPI2 --> Redis
-
-    Feedback --> PG
-    Feedback --> GitHub
-    Index --> VectorDB
-```
+See the [Community Registry](registry/index.md) documentation for details.
 
 ---
 
@@ -462,45 +52,49 @@ flowchart TB
 
 | Component | Technology | Purpose |
 |-----------|------------|---------|
-| API Server | FastAPI | REST API, WebSocket streaming |
-| CLI | Typer + Rich | Command-line interface |
-| Orchestration | LangGraph | Multi-agent workflows, state management |
-| LLM Framework | LangChain | Model abstraction, tool calling |
-| Observability | LangFuse | Tracing, cost tracking, prompt management |
-| Knowledge DB | SQLite + FTS5 | Issues, PRs, papers with full-text search |
-| Session State | In-memory / SQLite | Single instance, simple persistence |
-| Vector Store | FAISS/Qdrant | Semantic search (future) |
+| API Server | FastAPI | REST API, SSE streaming |
+| CLI | Typer + Rich | Command-line interface (`pip install open-science-assistant`) |
+| Agent Orchestration | LangGraph | State machine for conversation + tool-calling loop |
+| LLM Abstraction | LiteLLM | Provider routing, prompt caching |
+| Knowledge Storage | SQLite + FTS5 | Issues, PRs, docs with full-text search (BM25) |
+| Observability | LangFuse | Tracing, cost tracking, quality metrics |
+| Deployment | Docker + GitHub Actions | CI/CD to GHCR, deploy via SSH |
+| Frontend | Cloudflare Pages | Widget hosting (demo.osc.earth) |
+| Reverse Proxy | Apache | api.osc.earth path-based routing |
 
 ### External API Integrations
 
-OSA integrates with existing validator and tool APIs rather than hosting validation engines locally. This approach:
-- Reduces deployment complexity (no need to maintain validator dependencies)
-- Ensures validation logic is always up-to-date
-- Leverages existing, well-tested infrastructure
+OSA integrates with existing validator and tool APIs rather than hosting validation engines locally:
 
-| Service | API Endpoint | Integration |
-|---------|--------------|-------------|
-| HED Validation | https://hedtools.org/hed | String, sidecar, spreadsheet, BIDS validation |
-| BIDS Validator | https://bids-validator.github.io | Dataset structure validation |
-| OpenALEX | https://api.openalex.org | Academic paper search |
-| GitHub API | https://api.github.com | Issues, PRs, discussions |
+| Service | Integration |
+|---------|-------------|
+| [HED Validation](https://hedtools.org/hed) | String, sidecar, spreadsheet, BIDS validation |
+| [OpenRouter](https://openrouter.ai) | LLM provider routing (Qwen, Claude, GPT, Gemini) |
+| [GitHub API](https://api.github.com) | Knowledge source (issues, PRs) |
+| [LangFuse](https://langfuse.com) | Observability and cost tracking |
 
-The assistant tools call these APIs on behalf of users, parsing results and presenting them in context.
+---
 
-### Why SQLite with FTS5 for Knowledge Sources?
+## Authentication
 
-For single-instance lab deployment, SQLite with FTS5 is the optimal choice:
+OSA supports two authentication modes:
 
-| Approach | Search Speed | Dependencies | Use Case |
-|----------|-------------|--------------|----------|
-| JSON files | O(n) linear | None | Tiny datasets (<1K) |
-| MongoDB | O(log n) indexed | External server | Multi-instance, large scale |
-| **SQLite + FTS5** | O(log n) indexed | None (stdlib) | **Single instance, 10K-1M records** |
-| PostgreSQL | O(log n) indexed | External server | Multi-instance, complex queries |
+- **Server API key** (`X-API-Key` header): Uses the server's configured LLM key with the community's default model
+- **BYOK (Bring Your Own Key)**: Users provide their own OpenRouter/OpenAI/Anthropic key via headers, allowing them to use any model
 
-**SQLite + FTS5 advantages:**
-- No external server (single file per project)
-- Full-text search with ranking (`bm25()`)
-- 100-1000x faster than JSON linear scan
-- Python stdlib (no extra dependencies)
-- Easy backup (just copy the file)
+---
+
+## Deployment
+
+OSA runs as a Docker container behind an Apache reverse proxy:
+
+| Environment | API URL | Frontend URL |
+|-------------|---------|-------------|
+| Production | `https://api.osc.earth/osa` | `https://demo.osc.earth` |
+| Development | `https://api.osc.earth/osa-dev` | `https://develop-demo.osc.earth` |
+
+CI/CD: GitHub Actions builds Docker images on push, tagged `:dev` (develop branch) or `:latest` (main branch). Deployment is a `docker pull` + restart on the lab server.
+
+---
+
+For the detailed internal architecture, see [Architecture Details](architecture-details.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,7 +152,9 @@ nav:
   - OSA:
       - osa/index.md
       - Getting Started: osa/getting-started.md
-      - Architecture: osa/architecture.md
+      - Architecture:
+          - Overview: osa/architecture.md
+          - Details: osa/architecture-details.md
       - Community Registry:
           - osa/registry/index.md
           - Adding a Community: osa/registry/quick-start.md


### PR DESCRIPTION
## Summary
- Replace all Mermaid diagrams in architecture page with two SVG diagrams (overview + detailed)
- Split architecture into two pages: Overview and Details
- Correct inaccurate components that were never implemented (router agent, PostgreSQL, Redis, vector store, multiple instances, background workers)
- All diagrams now reflect the actual deployed system

## Changes
- **architecture.md**: Rewritten as overview page with high-level SVG and accurate component descriptions
- **architecture-details.md**: New page with detailed infrastructure SVG, request flow, community routing, model selection, knowledge system, security, and CI/CD
- **architecture-overview.svg**: High-level diagram (researchers -> clients -> edge -> platform -> services)
- **architecture-diagram.svg**: Detailed infrastructure diagram with orthogonal arrow routing
- **mkdocs.yml**: Architecture nav expanded to Overview + Details

## What was corrected
- [x] Removed Router Agent / Supervisor pattern (not implemented)
- [x] Removed PostgreSQL, Redis, Vector Store (actual: SQLite + FTS5, in-memory sessions)
- [x] Removed multiple FastAPI instances / load balancer (actual: single instance)
- [x] Removed background workers (actual: CLI-driven knowledge sync)
- [x] Added actual Apache reverse proxy setup
- [x] Added accurate BYOK authentication flow
- [x] Added CI/CD pipeline details

## Test plan
- [x] mkdocs build succeeds with no errors
- [ ] Verify SVGs render correctly on the docs site
- [ ] Check dark mode appearance