### PR TITLE
Add sticky OS tabs across docs and courses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,5 @@ node_modules/
 # Wrangler
 .wrangler/
 
-# Claude Code
-CLAUDE.md
-
-# Planning files
-plan.md
-ideas.md
+# Planning files (scratch only)
 scratch_notes.md
-research.md
-.context/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# OSC Documentation
+
+Documentation site for the Open Science Collective (OSC), built with MkDocs Material.
+
+## Two Documentation Sources
+
+This repo serves two independent MkDocs sites from two config files, each deploying to its own subdomain:
+
+| Config | docs_dir | Subdomain | Content |
+|--------|----------|-----------|---------|
+| `mkdocs.yml` | `docs/` | docs.osc.earth | OSC and OSA documentation |
+| `mkdocs-courses.yml` | `courses/` | courses.osc.earth | Course materials |
+
+Both share the `overrides/` directory for theme customizations.
+
+## Build and Serve
+
+```bash
+# Main docs
+uv run mkdocs serve                          # dev server (docs.osc.earth)
+uv run mkdocs build                          # build to site/
+
+# Courses
+uv run mkdocs serve -f mkdocs-courses.yml    # dev server (courses.osc.earth)
+uv run mkdocs build -f mkdocs-courses.yml    # build to site-courses/
+```
+
+## OS-Specific Tabs
+
+Both sites use `content.tabs.link` (Material for MkDocs), which syncs tab selections across the page and persists the choice in localStorage. For this to work, all OS tab groups must use exactly these labels:
+
+- `=== "macOS"`
+- `=== "Linux"`
+- `=== "Windows"`
+
+Never use combined labels like "macOS / Linux" or qualified labels like "macOS: Homebrew"; they break cross-group syncing.
+
+## Submodules
+
+- `osa/` -- the [OSA application repo](https://github.com/OpenScience-Collective/osa) (git submodule). Not part of the docs build; used for API reference generation when enabled.

--- a/courses/agentic-research/week-01.md
+++ b/courses/agentic-research/week-01.md
@@ -77,7 +77,9 @@ ls -la # List with details
 
 Package managers let you install software from the command line. Think of them as an app store for developer tools.
 
-=== "macOS: Homebrew"
+=== "macOS"
+
+    Install [Homebrew](https://brew.sh), the standard macOS package manager:
 
     ```bash
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -89,9 +91,17 @@ Package managers let you install software from the command line. Think of them a
     brew --version
     ```
 
-=== "Linux (Debian/Ubuntu) or WSL"
+=== "Linux"
 
     You already have `apt`. Update it:
+
+    ```bash
+    sudo apt update
+    ```
+
+=== "Windows"
+
+    Your WSL Ubuntu terminal already has `apt` (see Step 1). Update it:
 
     ```bash
     sudo apt update
@@ -107,7 +117,15 @@ You need two command-line tools: `git` for version control and `gh` (the GitHub 
     brew install git gh
     ```
 
-=== "Linux or WSL"
+=== "Linux"
+
+    ```bash
+    sudo apt install git gh
+    ```
+
+=== "Windows"
+
+    In your WSL Ubuntu terminal:
 
     ```bash
     sudo apt install git gh
@@ -241,6 +259,21 @@ ssh-add ~/.ssh/id_ed25519
     # Select and copy the output manually
     ```
 
+=== "Windows"
+
+    In your WSL Ubuntu terminal:
+
+    ```bash
+    cat ~/.ssh/id_ed25519.pub
+    # Select and copy the output manually
+    ```
+
+    Or in PowerShell:
+
+    ```powershell
+    Get-Content ~\.ssh\id_ed25519.pub | Set-Clipboard
+    ```
+
 Then add it to GitHub:
 
 1. Go to [github.com/settings/keys](https://github.com/settings/keys)
@@ -371,13 +404,21 @@ If all of these work, you are ready for Week 2.
 !!! note "Install Claude Code"
     Before Week 2, install [Claude Code](https://claude.ai/claude-code):
 
-    === "macOS / Linux"
+    === "macOS"
 
         ```bash
         brew install claude-code
         ```
 
-    === "Official installer"
+    === "Linux"
+
+        ```bash
+        curl -fsSL https://claude.ai/install-cli | sh
+        ```
+
+    === "Windows"
+
+        In your WSL Ubuntu terminal:
 
         ```bash
         curl -fsSL https://claude.ai/install-cli | sh

--- a/docs/osa/cli-reference.md
+++ b/docs/osa/cli-reference.md
@@ -365,8 +365,26 @@ osa ask -a hed "What is HED?" -o json | jq '.answer'
 
 ### Using with Environment Variable
 
-```bash
-export OPENROUTER_API_KEY=sk-or-v1-your-key
-osa ask -a hed "What is HED?"
-osa chat -a bids
-```
+=== "macOS"
+
+    ```bash
+    export OPENROUTER_API_KEY=sk-or-v1-your-key
+    osa ask -a hed "What is HED?"
+    osa chat -a bids
+    ```
+
+=== "Linux"
+
+    ```bash
+    export OPENROUTER_API_KEY=sk-or-v1-your-key
+    osa ask -a hed "What is HED?"
+    osa chat -a bids
+    ```
+
+=== "Windows"
+
+    ```powershell
+    $env:OPENROUTER_API_KEY = "sk-or-v1-your-key"
+    osa ask -a hed "What is HED?"
+    osa chat -a bids
+    ```

--- a/docs/osa/development.md
+++ b/docs/osa/development.md
@@ -38,9 +38,27 @@ uv sync
 # Install pre-commit hooks
 uv run pre-commit install
 
-# Copy environment file
-cp .env.example .env
+# Copy environment file (see OS-specific command below)
 # Edit .env with your API keys
+```
+
+=== "macOS"
+
+    ```bash
+    cp .env.example .env
+    ```
+
+=== "Linux"
+
+    ```bash
+    cp .env.example .env
+    ```
+
+=== "Windows"
+
+    ```powershell
+    Copy-Item .env.example .env
+    ```
 ```
 
 ## Testing

--- a/docs/osa/getting-started.md
+++ b/docs/osa/getting-started.md
@@ -30,8 +30,16 @@ osa init
 You'll need an [OpenRouter API key](https://openrouter.ai/keys). The setup will:
 
 1. Prompt for your API key
-2. Save it securely to `~/.config/osa/credentials.yaml` (permissions 600)
+2. Save it securely to your config directory (see paths below)
 3. Test the connection to the API
+
+Config directory by platform:
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/osa/` |
+| Linux | `~/.config/osa/` |
+| Windows | `%APPDATA%\osa\` |
 
 Alternatively, pass the key directly:
 
@@ -63,10 +71,26 @@ osa ask -a hed "What is HED?" --api-key sk-or-v1-your-key
 
 Or set it via environment variable:
 
-```bash
-export OPENROUTER_API_KEY=sk-or-v1-your-key
-osa ask -a hed "What is HED?"
-```
+=== "macOS"
+
+    ```bash
+    export OPENROUTER_API_KEY=sk-or-v1-your-key
+    osa ask -a hed "What is HED?"
+    ```
+
+=== "Linux"
+
+    ```bash
+    export OPENROUTER_API_KEY=sk-or-v1-your-key
+    osa ask -a hed "What is HED?"
+    ```
+
+=== "Windows"
+
+    ```powershell
+    $env:OPENROUTER_API_KEY = "sk-or-v1-your-key"
+    osa ask -a hed "What is HED?"
+    ```
 
 ## For Developers (Server)
 
@@ -93,9 +117,23 @@ uv run pre-commit install
 
 Copy the example environment file:
 
-```bash
-cp .env.example .env
-```
+=== "macOS"
+
+    ```bash
+    cp .env.example .env
+    ```
+
+=== "Linux"
+
+    ```bash
+    cp .env.example .env
+    ```
+
+=== "Windows"
+
+    ```powershell
+    Copy-Item .env.example .env
+    ```
 
 Edit `.env` with your settings:
 

--- a/docs/osa/registry/local-testing.md
+++ b/docs/osa/registry/local-testing.md
@@ -40,16 +40,44 @@ Common validation errors and fixes:
 
 ## 2. Set Environment Variables
 
-```bash
-# Required: OpenRouter API key for LLM calls
-export OPENROUTER_API_KEY="your-key-here"
+=== "macOS"
 
-# Optional: API keys for admin functions (sync triggers)
-export API_KEYS="test-key-123"
+    ```bash
+    # Required: OpenRouter API key for LLM calls
+    export OPENROUTER_API_KEY="your-key-here"
 
-# Optional: Community-specific key (if using BYOK)
-# export OPENROUTER_API_KEY_MY_TOOL="community-specific-key"
-```
+    # Optional: API keys for admin functions (sync triggers)
+    export API_KEYS="test-key-123"
+
+    # Optional: Community-specific key (if using BYOK)
+    # export OPENROUTER_API_KEY_MY_TOOL="community-specific-key"
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Required: OpenRouter API key for LLM calls
+    export OPENROUTER_API_KEY="your-key-here"
+
+    # Optional: API keys for admin functions (sync triggers)
+    export API_KEYS="test-key-123"
+
+    # Optional: Community-specific key (if using BYOK)
+    # export OPENROUTER_API_KEY_MY_TOOL="community-specific-key"
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Required: OpenRouter API key for LLM calls
+    $env:OPENROUTER_API_KEY = "your-key-here"
+
+    # Optional: API keys for admin functions (sync triggers)
+    $env:API_KEYS = "test-key-123"
+
+    # Optional: Community-specific key (if using BYOK)
+    # $env:OPENROUTER_API_KEY_MY_TOOL = "community-specific-key"
+    ```
 
 ## 3. Start the Development Server
 
@@ -107,16 +135,44 @@ curl -X POST http://localhost:38528/my-tool/chat \
 
 The CLI is often easier for interactive testing:
 
-```bash
-# Set API key
-export OPENROUTER_API_KEY="your-key-here"
+=== "macOS"
 
-# Interactive chat (standalone mode, no server needed)
-uv run osa chat --community my-tool --standalone
+    ```bash
+    # Set API key
+    export OPENROUTER_API_KEY="your-key-here"
 
-# Single question
-uv run osa ask --community my-tool "What is My Tool?" --standalone
-```
+    # Interactive chat (standalone mode, no server needed)
+    uv run osa chat --community my-tool --standalone
+
+    # Single question
+    uv run osa ask --community my-tool "What is My Tool?" --standalone
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Set API key
+    export OPENROUTER_API_KEY="your-key-here"
+
+    # Interactive chat (standalone mode, no server needed)
+    uv run osa chat --community my-tool --standalone
+
+    # Single question
+    uv run osa ask --community my-tool "What is My Tool?" --standalone
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Set API key
+    $env:OPENROUTER_API_KEY = "your-key-here"
+
+    # Interactive chat (standalone mode, no server needed)
+    uv run osa chat --community my-tool --standalone
+
+    # Single question
+    uv run osa ask --community my-tool "What is My Tool?" --standalone
+    ```
 
 The `--standalone` flag runs the assistant without needing the backend server.
 
@@ -187,13 +243,35 @@ curl -X POST http://localhost:38528/my-tool/ask \
 
 ### Server won't start
 
-```bash
-# Check if port is already in use
-lsof -i :38528
+=== "macOS"
 
-# Use a different port
-uv run uvicorn src.api.main:app --reload --port 38529
-```
+    ```bash
+    # Check if port is already in use
+    lsof -i :38528
+
+    # Use a different port
+    uv run uvicorn src.api.main:app --reload --port 38529
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Check if port is already in use
+    lsof -i :38528
+
+    # Use a different port
+    uv run uvicorn src.api.main:app --reload --port 38529
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Check if port is already in use
+    netstat -ano | findstr :38528
+
+    # Use a different port
+    uv run uvicorn src.api.main:app --reload --port 38529
+    ```
 
 ### "Assistant not found" error
 

--- a/docs/osa/troubleshooting.md
+++ b/docs/osa/troubleshooting.md
@@ -14,10 +14,27 @@ Before diving into specific errors:
    ```
 
 2. **Check environment variables:**
-   ```bash
-   echo $OPENROUTER_API_KEY_YOUR_COMMUNITY
-   # Should print your API key, not empty
-   ```
+
+    === "macOS"
+
+        ```bash
+        echo $OPENROUTER_API_KEY_YOUR_COMMUNITY
+        # Should print your API key, not empty
+        ```
+
+    === "Linux"
+
+        ```bash
+        echo $OPENROUTER_API_KEY_YOUR_COMMUNITY
+        # Should print your API key, not empty
+        ```
+
+    === "Windows"
+
+        ```powershell
+        echo $env:OPENROUTER_API_KEY_YOUR_COMMUNITY
+        # Should print your API key, not empty
+        ```
 
 3. **Test API key:**
    ```bash
@@ -260,22 +277,46 @@ Validation passed with warnings
 **Solution:**
 
 **For local testing:**
-```bash
-# Add to shell profile (~/.zshrc or ~/.bashrc)
-echo 'export OPENROUTER_API_KEY_MYPROJECT="sk-or-v1-..."' >> ~/.zshrc
-source ~/.zshrc
 
-# Verify
-echo $OPENROUTER_API_KEY_MYPROJECT
-```
+=== "macOS"
+
+    ```bash
+    # Add to shell profile
+    echo 'export OPENROUTER_API_KEY_MYPROJECT="sk-or-v1-..."' >> ~/.zshrc
+    source ~/.zshrc
+
+    # Verify
+    echo $OPENROUTER_API_KEY_MYPROJECT
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Add to shell profile
+    echo 'export OPENROUTER_API_KEY_MYPROJECT="sk-or-v1-..."' >> ~/.bashrc
+    source ~/.bashrc
+
+    # Verify
+    echo $OPENROUTER_API_KEY_MYPROJECT
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Set for current session
+    $env:OPENROUTER_API_KEY_MYPROJECT = "sk-or-v1-..."
+
+    # Set permanently (persists across sessions)
+    [Environment]::SetEnvironmentVariable("OPENROUTER_API_KEY_MYPROJECT", "sk-or-v1-...", "User")
+
+    # Verify
+    echo $env:OPENROUTER_API_KEY_MYPROJECT
+    ```
 
 **For production (server):**
 ```bash
 # Add to .env file
 echo 'OPENROUTER_API_KEY_MYPROJECT="sk-or-v1-..."' >> .env
-
-# Or add to environment
-export OPENROUTER_API_KEY_MYPROJECT="sk-or-v1-..."
 ```
 
 **Verify:**
@@ -301,10 +342,27 @@ Invalid API key (401 Unauthorized)
 **Solution:**
 
 1. **Verify key format:**
-   ```bash
-   echo $OPENROUTER_API_KEY_MYPROJECT
-   # Should start with: sk-or-v1-
-   ```
+
+    === "macOS"
+
+        ```bash
+        echo $OPENROUTER_API_KEY_MYPROJECT
+        # Should start with: sk-or-v1-
+        ```
+
+    === "Linux"
+
+        ```bash
+        echo $OPENROUTER_API_KEY_MYPROJECT
+        # Should start with: sk-or-v1-
+        ```
+
+    === "Windows"
+
+        ```powershell
+        echo $env:OPENROUTER_API_KEY_MYPROJECT
+        # Should start with: sk-or-v1-
+        ```
 
 2. **Check key on OpenRouter:**
    - Visit https://openrouter.ai/keys

--- a/mkdocs-courses.yml
+++ b/mkdocs-courses.yml
@@ -13,6 +13,7 @@ repo_url: https://github.com/OpenScience-Collective
 copyright: Copyright &copy; 2026 Open Science Collective
 
 docs_dir: courses
+site_dir: site-courses
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

- Standardize all OS-specific tab groups to use consistent "macOS", "Linux", "Windows" labels so `content.tabs.link` syncs selections site-wide and persists via localStorage
- Add OS tabs to main docs pages (getting-started, troubleshooting, cli-reference, local-testing, development) for env vars, file operations, and port checking
- Add `site_dir: site-courses` to `mkdocs-courses.yml` to prevent build collision with main docs
- Add project `CLAUDE.md` documenting the two-source/two-subdomain setup
- Track `CLAUDE.md` and `.context/` in git

## Test plan

- [x] Both `mkdocs build` and `mkdocs build -f mkdocs-courses.yml` succeed
- [x] All OS tab groups use exactly "macOS", "Linux", "Windows" labels
- [x] Non-OS tabs (Students/Faculty/Research labs) unchanged
- [ ] Verify in browser: clicking "Windows" on one tab group switches all others
- [ ] Verify tab selection persists across page navigation
- [ ] Verify tab selection persists across page reload

Closes #13