### PR TITLE
Fix Week 1 Claude Code install commands

### DIFF
--- a/courses/agentic-research/week-01.md
+++ b/courses/agentic-research/week-01.md
@@ -402,18 +402,26 @@ If all of these work, you are ready for Week 2.
 ## Before Next Session
 
 !!! note "Install Claude Code"
-    Before Week 2, install [Claude Code](https://claude.ai/claude-code):
+    Before Week 2, install [Claude Code](https://code.claude.com/docs/en/overview):
 
     === "macOS"
 
+        Native install (recommended, auto-updates):
+
         ```bash
-        brew install claude-code
+        curl -fsSL https://claude.ai/install.sh | bash
+        ```
+
+        Or via Homebrew:
+
+        ```bash
+        brew install --cask claude-code
         ```
 
     === "Linux"
 
         ```bash
-        curl -fsSL https://claude.ai/install-cli | sh
+        curl -fsSL https://claude.ai/install.sh | bash
         ```
 
     === "Windows"
@@ -421,7 +429,13 @@ If all of these work, you are ready for Week 2.
         In your WSL Ubuntu terminal:
 
         ```bash
-        curl -fsSL https://claude.ai/install-cli | sh
+        curl -fsSL https://claude.ai/install.sh | bash
+        ```
+
+        Or directly in PowerShell (requires [Git for Windows](https://git-scm.com/downloads/win)):
+
+        ```powershell
+        irm https://claude.ai/install.ps1 | iex
         ```
 
     Verify:


### PR DESCRIPTION
Closes #17

## Summary
- Update \`courses/agentic-research/week-01.md\` "Before Next Session" block with the canonical install commands from code.claude.com
- Flagged during PR #16 review; students who follow Week 1's homework as written hit broken installs

## Changes
- macOS: \`brew install claude-code\` -> \`brew install --cask claude-code\` (the cask is required)
- macOS: added the native \`curl -fsSL https://claude.ai/install.sh | bash\` path as the recommended option (auto-updates)
- Linux and WSL: \`https://claude.ai/install-cli | sh\` -> \`https://claude.ai/install.sh | bash\` (the old URL is no longer canonical)
- Windows: added a PowerShell option (\`irm https://claude.ai/install.ps1 | iex\`) with a Git for Windows prerequisite note
- Anchor link: \`claude.ai/claude-code\` -> \`code.claude.com/docs/en/overview\`

## Test plan
- [ ] \`uv run mkdocs serve -f mkdocs-courses.yml\` and confirm the admonition renders correctly
- [ ] Tab syncing across macOS / Linux / Windows still works (labels unchanged)