### PR TITLE
Add cross-site footer links and rewrite logo to main site

### DIFF
--- a/mkdocs-courses.yml
+++ b/mkdocs-courses.yml
@@ -111,6 +111,7 @@ markdown_extensions:
   - pymdownx.tilde
 
 extra:
+  homepage: https://osc.earth
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/OpenScience-Collective

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ markdown_extensions:
   - pymdownx.tilde
 
 extra:
+  homepage: https://osc.earth
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/OpenScience-Collective

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <style>
+    .md-osc-sitelinks {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.35rem 0.6rem;
+      margin-bottom: 0.4rem;
+      font-size: 0.72rem;
+      font-weight: 500;
+    }
+    .md-osc-sitelinks a {
+      color: var(--md-footer-fg-color);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 120ms ease;
+    }
+    .md-osc-sitelinks a:hover,
+    .md-osc-sitelinks a:focus {
+      border-bottom-color: currentColor;
+    }
+    .md-osc-sitelinks span {
+      opacity: 0.5;
+    }
+  </style>
+{% endblock %}
+
+{% block libs %}
+  {{ super() }}
+  <script>
+    (function () {
+      var HOME = "https://osc.earth";
+      function applyLogoLink() {
+        var selectors = [
+          "a.md-header__button.md-logo",
+          "a.md-header__title"
+        ];
+        selectors.forEach(function (sel) {
+          document.querySelectorAll(sel).forEach(function (el) {
+            el.setAttribute("href", HOME);
+          });
+        });
+      }
+      if (typeof document$ !== "undefined" && document$.subscribe) {
+        document$.subscribe(applyLogoLink);
+      } else {
+        document.addEventListener("DOMContentLoaded", applyLogoLink);
+      }
+    })();
+  </script>
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,9 +8,20 @@
       flex-wrap: wrap;
       justify-content: center;
       gap: 0.35rem 0.6rem;
-      margin-bottom: 0.4rem;
+      margin: 0 0 0.4rem;
+      padding: 0;
+      list-style: none;
       font-size: 0.72rem;
       font-weight: 500;
+    }
+    .md-osc-sitelinks li {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+    }
+    .md-osc-sitelinks li + li::before {
+      content: "·";
+      opacity: 0.5;
     }
     .md-osc-sitelinks a {
       color: var(--md-footer-fg-color);
@@ -22,33 +33,5 @@
     .md-osc-sitelinks a:focus {
       border-bottom-color: currentColor;
     }
-    .md-osc-sitelinks span {
-      opacity: 0.5;
-    }
   </style>
-{% endblock %}
-
-{% block libs %}
-  {{ super() }}
-  <script>
-    (function () {
-      var HOME = "https://osc.earth";
-      function applyLogoLink() {
-        var selectors = [
-          "a.md-header__button.md-logo",
-          "a.md-header__title"
-        ];
-        selectors.forEach(function (sel) {
-          document.querySelectorAll(sel).forEach(function (el) {
-            el.setAttribute("href", HOME);
-          });
-        });
-      }
-      if (typeof document$ !== "undefined" && document$.subscribe) {
-        document$.subscribe(applyLogoLink);
-      } else {
-        document.addEventListener("DOMContentLoaded", applyLogoLink);
-      }
-    })();
-  </script>
 {% endblock %}

--- a/overrides/partials/copyright.html
+++ b/overrides/partials/copyright.html
@@ -1,0 +1,23 @@
+{# Custom copyright partial with cross-site navigation links #}
+<div class="md-copyright">
+  <div class="md-copyright__highlight md-osc-sitelinks">
+    <a href="https://osc.earth">osc.earth</a>
+    <span aria-hidden="true">·</span>
+    <a href="https://docs.osc.earth">docs.osc.earth</a>
+    <span aria-hidden="true">·</span>
+    <a href="https://courses.osc.earth">courses.osc.earth</a>
+  </div>
+  {% if config.copyright %}
+    <div class="md-copyright__copyright">
+      {{ config.copyright }}
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    <div class="md-copyright__generator">
+      Made with
+      <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
+        Material for MkDocs
+      </a>
+    </div>
+  {% endif %}
+</div>

--- a/overrides/partials/copyright.html
+++ b/overrides/partials/copyright.html
@@ -1,23 +1,25 @@
-{# Custom copyright partial with cross-site navigation links #}
+{#-
+  Shadows Material's partials/copyright.html to add cross-site navigation.
+  Keep `md-copyright__highlight` and generator markup aligned with upstream:
+  https://github.com/squidfunk/mkdocs-material/blob/master/material/templates/partials/copyright.html
+-#}
 <div class="md-copyright">
-  <div class="md-copyright__highlight md-osc-sitelinks">
-    <a href="https://osc.earth">osc.earth</a>
-    <span aria-hidden="true">·</span>
-    <a href="https://docs.osc.earth">docs.osc.earth</a>
-    <span aria-hidden="true">·</span>
-    <a href="https://courses.osc.earth">courses.osc.earth</a>
-  </div>
+  <nav aria-label="Open Science Collective sites">
+    <ul class="md-osc-sitelinks">
+      <li><a href="https://osc.earth">osc.earth</a></li>
+      <li><a href="https://docs.osc.earth">docs.osc.earth</a></li>
+      <li><a href="https://courses.osc.earth">courses.osc.earth</a></li>
+    </ul>
+  </nav>
   {% if config.copyright %}
-    <div class="md-copyright__copyright">
+    <div class="md-copyright__highlight">
       {{ config.copyright }}
     </div>
   {% endif %}
   {% if not config.extra.generator == false %}
-    <div class="md-copyright__generator">
-      Made with
-      <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
-        Material for MkDocs
-      </a>
-    </div>
+    Made with
+    <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
+      Material for MkDocs
+    </a>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- Shared `overrides/` applied to both MkDocs configs (`docs.osc.earth`, `courses.osc.earth`).
- Header logo / site title now link to `https://osc.earth` (applied on each instant-nav swap via Material's `document$` observable).
- Footer shows three-site nav (`osc.earth` · `docs.osc.earth` · `courses.osc.earth`) above copyright and Material generator line.

## Files
- `overrides/main.html` — extends `base.html`; inlines footer-link CSS (`extrahead`) and logo-rewrite JS (`libs`).
- `overrides/partials/copyright.html` — custom copyright partial with cross-site links.

## Test plan
- [x] `uv run mkdocs build` passes
- [x] `uv run mkdocs build -f mkdocs-courses.yml` passes
- [x] Built HTML contains three `href=https://*.osc.earth` footer links on both sites
- [ ] Manual: `mkdocs serve` on both configs; click logo navigates to `osc.earth`; footer links render and work