### PR TITLE
Bump bullet font size to xl

### DIFF
--- a/docs/osa/presentations/slides/uc-open-2026/uc-open-2026.json
+++ b/docs/osa/presentations/slides/uc-open-2026/uc-open-2026.json
@@ -132,7 +132,7 @@
               { "text": "No resources to build a bespoke assistant", "animation": { "fragment": true, "type": "fade", "index": 2 } },
               { "text": "Users still ask the same questions every week", "animation": { "fragment": true, "type": "fade", "index": 4 } }
             ],
-            "style": { "fontSize": "large" },
+            "style": { "fontSize": "xl" },
             "position": { "area": "left", "order": 1 }
           },
           {
@@ -148,7 +148,7 @@
               { "text": "No citations, no source of truth", "animation": { "fragment": true, "type": "fade", "index": 3 } },
               { "text": "Trust erodes after one bad reply", "animation": { "fragment": true, "type": "fade", "index": 5 } }
             ],
-            "style": { "fontSize": "large" },
+            "style": { "fontSize": "xl" },
             "position": { "area": "right", "order": 1 }
           },
           {
@@ -256,7 +256,7 @@
               { "text": "Per-community budget caps, maintainer alerts", "animation": { "fragment": true, "type": "fade", "index": 3 } },
               { "text": "**status.osc.earth/osa**, public trust signal", "animation": { "fragment": true, "type": "fade", "index": 4 } }
             ],
-            "style": { "fontSize": "medium" },
+            "style": { "fontSize": "xl" },
             "position": { "area": "right", "order": 1 }
           }
         ],
@@ -297,7 +297,7 @@
               { "text": "**Budget** caps cost per community", "animation": { "fragment": true, "type": "fade", "index": 4 } },
               { "text": "**System prompt** = the voice", "animation": { "fragment": true, "type": "fade", "index": 5 } }
             ],
-            "style": { "fontSize": "large" },
+            "style": { "fontSize": "xl" },
             "position": { "area": "right", "order": 1 }
           },
           {
@@ -345,7 +345,7 @@
               { "text": "**docs.osc.earth/osa**", "animation": { "fragment": true, "type": "fade", "index": 4 } },
               { "text": "**demo.osc.earth**, try any assistant live", "animation": { "fragment": true, "type": "fade", "index": 5 } }
             ],
-            "style": { "fontSize": "large" },
+            "style": { "fontSize": "xl" },
             "position": { "area": "right", "order": 1 }
           },
           {


### PR DESCRIPTION
## Summary
Bullets on slides 3 (friction), 6 (pipeline-dashboard), 7 (yaml-onboarding), 8 (usage-join) were set to \`large\` (1.5rem) or \`medium\` (1.2rem). Callouts render at ~2rem, so bullets felt undersized next to them. All five bullet blocks now set to \`xl\` (2rem).

## Test plan
- [ ] Open \`docs/osa/presentations/slides/uc-open-2026/presentation.html?presentation=./uc-open-2026.json\`. Step through slides 3, 6, 7, 8 and confirm bullets read at similar weight to the footer callout.
- [ ] Watch for overflow on slides 7 and 8 (6 items each). If they spill, drop those two back to \`large\`.