### PR TITLE
Bump osc-model paragraphs and one-platform list to xl

### DIFF
--- a/docs/osa/presentations/slides/uc-open-2026/uc-open-2026.json
+++ b/docs/osa/presentations/slides/uc-open-2026/uc-open-2026.json
@@ -73,21 +73,21 @@
           {
             "type": "text",
             "content": "**Open-source research software is underfunded.** One maintainer often holds up a whole field.",
-            "style": { "fontSize": "large", "alignment": "left", "color": "#0F172A" },
+            "style": { "fontSize": "xl", "alignment": "left", "color": "#0F172A" },
             "position": { "area": "left", "order": 0 },
             "animation": { "fragment": true, "type": "fade", "index": 0 }
           },
           {
             "type": "text",
             "content": "**OSC thesis:** a small overhead on grant budgets funds it forever.",
-            "style": { "fontSize": "large", "alignment": "left", "color": "#0F172A" },
+            "style": { "fontSize": "xl", "alignment": "left", "color": "#0F172A" },
             "position": { "area": "left", "order": 1 },
             "animation": { "fragment": true, "type": "fade", "index": 1 }
           },
           {
             "type": "text",
             "content": "**Share the stack.** Pool dev money for tools everyone uses, like this assistant.",
-            "style": { "fontSize": "large", "alignment": "left", "color": "#0F172A" },
+            "style": { "fontSize": "xl", "alignment": "left", "color": "#0F172A" },
             "position": { "area": "left", "order": 2 },
             "animation": { "fragment": true, "type": "fade", "index": 2 }
           },
@@ -189,7 +189,7 @@
           {
             "type": "text",
             "content": "**Seven live assistants**, one stack:\n\n- BIDS · Brain Imaging Data Structure\n- EEGLAB · MATLAB EEG toolbox\n- FieldTrip · MEG / EEG / iEEG\n- HED · Hierarchical Event Descriptors\n- MetaBCI · Brain-Computer Interfaces\n- MNE-Python · neurophysiology\n- NEMAR · BIDS data archive\n\n*Same onboarding. Each community keeps its own expertise.*",
-            "style": { "fontSize": "medium" },
+            "style": { "fontSize": "xl" },
             "position": { "area": "right", "order": 1 }
           }
         ],


### PR DESCRIPTION
## Summary
- **osc-model** (slide 2) left paragraphs: \`large\` (1.5rem) → \`xl\` (2rem). They read thin next to the big right-column screenshot.
- **one-platform** (slide 4) community list (text element with markdown bullets): \`medium\` (1.2rem) → \`xl\` (2rem). It was visibly smaller than the bullets on other slides.
- Bullets on slides 3, 6, 7, 8 intentionally kept at \`xl\` per user call (avoid matching header weight).

## Test plan
- [ ] Open \`docs/osa/presentations/slides/uc-open-2026/presentation.html?presentation=./uc-open-2026.json\`, step to slide 2 and 4, confirm text reads at similar weight to bullets on slides 3/6/7/8.