### PR TITLE
Add OSCAR submodule auto-sync (matches OSA)

### DIFF
--- a/.github/workflows/sync-oscar-submodule.yml
+++ b/.github/workflows/sync-oscar-submodule.yml
@@ -1,0 +1,40 @@
+name: Sync OSCAR Submodule
+
+on:
+  repository_dispatch:
+    types: [oscar-updated]
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly Monday 6am UTC as fallback
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Update OSCAR submodule
+        run: |
+          git submodule update --remote oscar
+          echo "Updated OSCAR submodule to $(git -C oscar rev-parse --short HEAD)"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "sync: update OSCAR submodule to latest"
+          title: "sync: update OSCAR submodule to latest"
+          body: |
+            Automated update of the OSCAR submodule to track latest changes.
+
+            Triggered by: ${{ github.event_name }}
+          branch: sync/oscar-submodule
+          labels: sync
+          delete-branch: true


### PR DESCRIPTION
Mirrors sync-osa-submodule.yml for the new oscar submodule so OSCAR edits propagate to docs.osc.earth automatically: weekly cron fallback, manual workflow_dispatch, and a repository_dispatch (oscar-updated) hook. The sync opens a PR that, once merged, triggers the existing auto-deploy.