### PR TITLE
Direct-push submodule sync instead of broken PR step

### DIFF
--- a/.github/workflows/sync-osa-submodule.yml
+++ b/.github/workflows/sync-osa-submodule.yml
@@ -11,8 +11,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write   # push the submodule bump to main
+      actions: write    # dispatch the deploy workflow
 
     steps:
       - name: Checkout
@@ -24,17 +24,22 @@ jobs:
       - name: Update OSA submodule
         run: |
           git submodule update --remote osa
-          echo "Updated OSA submodule to $(git -C osa rev-parse --short HEAD)"
+          echo "OSA now at $(git -C osa rev-parse --short HEAD)"
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "sync: update OSA submodule to latest"
-          title: "sync: update OSA submodule to latest"
-          body: |
-            Automated update of the OSA submodule to track latest changes.
-
-            Triggered by: ${{ github.event_name }}
-          branch: sync/osa-submodule
-          labels: sync
-          delete-branch: true
+      - name: Commit, push, and deploy if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- osa; then
+            echo "Submodule already up to date; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add osa
+          git commit -m "sync: update OSA submodule to $(git -C osa rev-parse --short HEAD)"
+          git push origin HEAD:main
+          echo "Pushed submodule bump; triggering deploy."
+          # A GITHUB_TOKEN push does not trigger deploy.yml (recursion guard),
+          # so dispatch it explicitly. workflow_dispatch is exempt from that guard.
+          gh workflow run deploy.yml --ref main

--- a/.github/workflows/sync-oscar-submodule.yml
+++ b/.github/workflows/sync-oscar-submodule.yml
@@ -11,8 +11,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write   # push the submodule bump to main
+      actions: write    # dispatch the deploy workflow
 
     steps:
       - name: Checkout
@@ -24,17 +24,22 @@ jobs:
       - name: Update OSCAR submodule
         run: |
           git submodule update --remote oscar
-          echo "Updated OSCAR submodule to $(git -C oscar rev-parse --short HEAD)"
+          echo "OSCAR now at $(git -C oscar rev-parse --short HEAD)"
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "sync: update OSCAR submodule to latest"
-          title: "sync: update OSCAR submodule to latest"
-          body: |
-            Automated update of the OSCAR submodule to track latest changes.
-
-            Triggered by: ${{ github.event_name }}
-          branch: sync/oscar-submodule
-          labels: sync
-          delete-branch: true
+      - name: Commit, push, and deploy if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- oscar; then
+            echo "Submodule already up to date; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add oscar
+          git commit -m "sync: update OSCAR submodule to $(git -C oscar rev-parse --short HEAD)"
+          git push origin HEAD:main
+          echo "Pushed submodule bump; triggering deploy."
+          # A GITHUB_TOKEN push does not trigger deploy.yml (recursion guard),
+          # so dispatch it explicitly. workflow_dispatch is exempt from that guard.
+          gh workflow run deploy.yml --ref main


### PR DESCRIPTION
The sync-oscar-submodule and sync-osa-submodule workflows used peter-evans/create-pull-request, whose final step fails with 'GitHub Actions is not permitted to create or approve pull requests' (org setting). The sync branch was pushed but no PR ever opened, so submodule bumps never landed. That is why the HED/EEGLAB/HEDit examples were stale on docs.osc.earth until a manual sync (PR #35).

This replaces the PR step in both workflows with a direct commit of the submodule bump to main, guarded by a no-op check when already current. Because a GITHUB_TOKEN push does not re-trigger deploy.yml, the job then dispatches deploy.yml explicitly (workflow_dispatch is exempt from the recursion guard). Job permissions are contents:write plus actions:write; no org setting or PAT needed.

Result: the weekly cron and any manual/dispatch run now fully auto-deploy. A push-triggered (instant) path can be added later with a PAT-based notify workflow in the OSCAR/OSA repos.